### PR TITLE
[FEAT] 사장님 - 계좌 CRUD 기능 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/chat/domain/ChatMessage.java
+++ b/src/main/java/konkuk/chacall/domain/chat/domain/ChatMessage.java
@@ -2,7 +2,7 @@ package konkuk.chacall.domain.chat.domain;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.chat.domain.value.MessageContentType;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/konkuk/chacall/domain/chat/domain/ChatRoom.java
+++ b/src/main/java/konkuk/chacall/domain/chat/domain/ChatRoom.java
@@ -1,7 +1,7 @@
 package konkuk.chacall.domain.chat.domain;
 
 import jakarta.persistence.*;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
@@ -2,7 +2,7 @@ package konkuk.chacall.domain.foodtruck.domain;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.foodtruck.domain.value.*;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.converter.MenuCategoryListConverter;
 import konkuk.chacall.global.common.converter.PhotoUrlListConverter;
 import konkuk.chacall.global.common.domain.BaseEntity;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/Rating.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/Rating.java
@@ -1,7 +1,7 @@
 package konkuk.chacall.domain.foodtruck.domain;
 
 import jakarta.persistence.*;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/konkuk/chacall/domain/member/application/MemberService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/MemberService.java
@@ -1,0 +1,4 @@
+package konkuk.chacall.domain.member.application;
+
+public class MemberService {
+}

--- a/src/main/java/konkuk/chacall/domain/member/domain/SavedFoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/SavedFoodTruck.java
@@ -1,8 +1,8 @@
-package konkuk.chacall.domain.user.member.domain;
+package konkuk.chacall.domain.member.domain;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.foodtruck.domain.FoodTruck;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/konkuk/chacall/domain/member/presentation/MemberController.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/MemberController.java
@@ -1,0 +1,4 @@
+package konkuk.chacall.domain.member.presentation;
+
+public class MemberController {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,0 +1,4 @@
+package konkuk.chacall.domain.owner.application;
+
+public class OwnerService {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -41,5 +41,12 @@ public class OwnerService {
         bankAccountService.updateBankAccount(ownerId, bankAccountId, request);
     }
 
+    public void deleteBankAccount(Long ownerId, Long bankAccountId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 계좌 삭제 로직 호출
+        bankAccountService.deleteBankAccount(ownerId, bankAccountId);
+    }
 
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,7 +1,7 @@
 package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
-import konkuk.chacall.domain.owner.application.util.OwnerValidator;
+import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,9 +1,11 @@
 package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
+import konkuk.chacall.domain.owner.application.util.OwnerValidator;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
+import konkuk.chacall.domain.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -12,16 +14,32 @@ import org.springframework.stereotype.Service;
 public class OwnerService {
 
     private final BankAccountService bankAccountService;
+    // 파사드에서 사장님 검증을 거침으로써 실제 계좌 관련 서비스 로직에서는 사장님 검증에 신경쓰지 않도록 책임 분리
+    private final OwnerValidator ownerValidator;
 
     public void registerBankAccount(RegisterBankAccountRequest request, Long ownerId) {
-        bankAccountService.registerBankAccount(request, ownerId);
+        // 사장님인지 먼저 검증
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        // 검증된 유저 정보를 넘겨 계좌 등록 로직 호출
+        bankAccountService.registerBankAccount(request, owner);
     }
 
     public BankAccountResponse getBankAccount(Long ownerId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 계좌 조회 로직 호출
         return bankAccountService.getBankAccount(ownerId);
     }
 
     public void updateBankAccount(Long ownerId, Long bankAccountId, UpdateBankAccountRequest request) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 계좌 수정 로직 호출
         bankAccountService.updateBankAccount(ownerId, bankAccountId, request);
     }
+
+
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,7 +1,8 @@
 package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
-import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -13,5 +14,9 @@ public class OwnerService {
 
     public void registerBankAccount(RegisterBankAccountRequest request, Long ownerId) {
         bankAccountService.registerBankAccount(request, ownerId);
+    }
+
+    public BankAccountResponse getBankAccount(Long ownerId) {
+        return bankAccountService.getBankAccount(ownerId);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,4 +1,17 @@
 package konkuk.chacall.domain.owner.application;
 
+import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
+import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
 public class OwnerService {
+
+    private final BankAccountService bankAccountService;
+
+    public void registerBankAccount(RegisterBankAccountRequest request, Long ownerId) {
+        bankAccountService.registerBankAccount(request, ownerId);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -2,6 +2,7 @@ package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,5 +19,9 @@ public class OwnerService {
 
     public BankAccountResponse getBankAccount(Long ownerId) {
         return bankAccountService.getBankAccount(ownerId);
+    }
+
+    public void updateBankAccount(Long ownerId, Long bankAccountId, UpdateBankAccountRequest request) {
+        bankAccountService.updateBankAccount(ownerId, bankAccountId, request);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -36,12 +36,7 @@ public class BankAccountService {
             throw new BusinessException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
         }
 
-        BankAccount bankAccount = BankAccount.builder()
-                .bankName(request.bankName())
-                .accountHolderName(request.accountHolderName())
-                .accountNumber(request.accountNumber())
-                .owner(owner)
-                .build();
+        BankAccount bankAccount = BankAccount.of(request.bankName(), request.accountHolderName(), request.accountNumber(), owner);
 
         bankAccountRepository.save(bankAccount);
     }

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -6,6 +6,7 @@ import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountR
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.BusinessException;
 import konkuk.chacall.global.common.exception.DomainRuleException;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
@@ -27,12 +28,12 @@ public class BankAccountService {
 
         // 해당 유저의 계좌가 이미 있는지 확인
         if (bankAccountRepository.existsByOwner_UserId(owner.getUserId())) {
-            throw new DomainRuleException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER);
+            throw new BusinessException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER);
         }
 
         // 중복 계좌 검증
         if (bankAccountRepository.existsByAccountNumber(request.accountNumber())) {
-            throw new DomainRuleException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
+            throw new BusinessException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
         }
 
         BankAccount bankAccount = BankAccount.builder()
@@ -64,7 +65,7 @@ public class BankAccountService {
         // 수정하려는 계좌번호가 현재와 다를 경우에만, 시스템 전체에서 중복되는지 검증
         if (!bankAccount.getAccountNumber().equals(request.accountNumber())) {
             if (bankAccountRepository.existsByAccountNumber(request.accountNumber())) {
-                throw new DomainRuleException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
+                throw new BusinessException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
             }
         }
 

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -44,7 +44,7 @@ public class BankAccountService {
 
     public BankAccountResponse getBankAccount(Long ownerId) {
         // 계좌 조회
-        Optional<BankAccount> bankAccountOptional = bankAccountRepository.findByOwner_UserId(ownerId);
+        Optional<BankAccount> bankAccountOptional = bankAccountRepository.findByOwnerId(ownerId);
 
         return bankAccountOptional
                 .map(BankAccountResponse::from)       // 계좌가 존재하면 DTO 로 변환

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -1,0 +1,44 @@
+package konkuk.chacall.domain.owner.application.bankAccount;
+
+import konkuk.chacall.domain.owner.domain.model.BankAccount;
+import konkuk.chacall.domain.owner.domain.repository.BankAccountRepository;
+import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import konkuk.chacall.domain.user.domain.model.Role;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BankAccountService {
+
+    private final UserRepository userRepository;
+    private final BankAccountRepository bankAccountRepository;
+
+    @Transactional
+    public void registerBankAccount(RegisterBankAccountRequest request, Long ownerId) {
+        // 존재 여부 및 역할 검증 동시에
+        User owner = userRepository.findByUserIdAndRole(ownerId, Role.OWNER).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        // 중복 계좌 검증
+        if (bankAccountRepository.existsByOwner_UserIdAndAccountNumber(ownerId, request.accountNumber())) {
+            throw new DomainRuleException(ErrorCode.BANK_ACCOUNT_ALREADY_EXISTS);
+        }
+
+        BankAccount bankAccount = BankAccount.builder()
+                .bankName(request.bankName())
+                .accountHolderName(request.accountHolderName())
+                .accountNumber(request.accountNumber())
+                .owner(owner)
+                .build();
+
+        bankAccountRepository.save(bankAccount);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -2,7 +2,8 @@ package konkuk.chacall.domain.owner.application.bankAccount;
 
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 import konkuk.chacall.domain.owner.domain.repository.BankAccountRepository;
-import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
@@ -46,5 +47,20 @@ public class BankAccountService {
                 .build();
 
         bankAccountRepository.save(bankAccount);
+    }
+
+
+    public BankAccountResponse getBankAccount(Long ownerId) {
+
+        // 존재 여부 및 역할 검증 동시에
+        if (!userRepository.existsByUserIdAndRoleAndStatus(ownerId, Role.OWNER, BaseStatus.ACTIVE)) {
+            throw new EntityNotFoundException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 계좌 조회
+        BankAccount bankAccount = bankAccountRepository.findByOwner_UserId(ownerId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BANK_ACCOUNT_NOT_FOUND));
+
+        return BankAccountResponse.from(bankAccount);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/bankAccount/BankAccountService.java
@@ -82,8 +82,14 @@ public class BankAccountService {
     }
 
     private BankAccount findBankAccountAndVerifyOwner(Long ownerId, Long bankAccountId) {
-        return bankAccountRepository.findByBankAccountIdAndOwner_UserId(bankAccountId, ownerId)
+        BankAccount bankAccount = bankAccountRepository.findById(bankAccountId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.BANK_ACCOUNT_NOT_FOUND));
+
+        // 실제 소유주 여부 검증
+        bankAccount.verifyOwner(ownerId);
+
+        return bankAccount;
+
     }
 
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/util/OwnerValidator.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/util/OwnerValidator.java
@@ -1,0 +1,22 @@
+package konkuk.chacall.domain.owner.application.util;
+
+import konkuk.chacall.domain.user.domain.model.Role;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.global.common.domain.BaseStatus;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OwnerValidator {
+
+    private final UserRepository userRepository;
+
+    public User validateAndGetOwner(Long ownerId) {
+        return userRepository.findByUserIdAndRoleAndStatus(ownerId, Role.OWNER, BaseStatus.ACTIVE)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/validator/OwnerValidator.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/validator/OwnerValidator.java
@@ -1,15 +1,16 @@
-package konkuk.chacall.domain.owner.application.util;
+package konkuk.chacall.domain.owner.application.validator;
 
 import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.global.common.annotation.HelperService;
 import konkuk.chacall.global.common.domain.BaseStatus;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
-@Component
+@HelperService
 @RequiredArgsConstructor
 public class OwnerValidator {
 

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -3,11 +3,15 @@ package konkuk.chacall.domain.owner.domain.model;
 import jakarta.persistence.*;
 import konkuk.chacall.domain.user.domain.model.User;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "bank_accounts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class BankAccount {
 
     @Id

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -28,4 +28,10 @@ public class BankAccount {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
+
+    public void update(String bankName, String accountHolderName, String accountNumber) {
+        this.bankName = bankName;
+        this.accountHolderName = accountHolderName;
+        this.accountNumber = accountNumber;
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -22,11 +22,11 @@ public class BankAccount {
     @Column(length = 20, nullable = false)
     private String accountHolderName;
 
-    @Column(length = 30, nullable = false)
+    @Column(length = 30, nullable = false, unique = true)
     private String accountNumber;
 
     @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User owner;
 
     public void update(String bankName, String accountHolderName, String accountNumber) {

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -1,7 +1,7 @@
-package konkuk.chacall.domain.user.owner.domain;
+package konkuk.chacall.domain.owner.domain.model;
 
 import jakarta.persistence.*;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -2,6 +2,8 @@ package konkuk.chacall.domain.owner.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.*;
 
 @Entity
@@ -43,4 +45,11 @@ public class BankAccount {
         this.accountHolderName = accountHolderName;
         this.accountNumber = accountNumber;
     }
+
+    public void verifyOwner(Long ownerId) {
+        if (!this.owner.getUserId().equals(ownerId)) {
+            throw new DomainRuleException(ErrorCode.BANK_ACCOUNT_FORBIDDEN);
+        }
+    }
+
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -29,6 +29,15 @@ public class BankAccount {
     @JoinColumn(name = "user_id", nullable = false, unique = true)
     private User owner;
 
+    public static BankAccount of(String bankName, String accountHolderName, String accountNumber, User owner) {
+        return BankAccount.builder()
+                .bankName(bankName)
+                .accountHolderName(accountHolderName)
+                .accountNumber(accountNumber)
+                .owner(owner)
+                .build();
+    }
+
     public void update(String bankName, String accountHolderName, String accountNumber) {
         this.bankName = bankName;
         this.accountHolderName = accountHolderName;

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -2,15 +2,13 @@ package konkuk.chacall.domain.owner.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.user.domain.model.User;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Entity
 @Table(name = "bank_accounts")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
+@Getter
 @Builder
 public class BankAccount {
 

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -2,6 +2,7 @@ package konkuk.chacall.domain.owner.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.domain.BaseEntity;
 import konkuk.chacall.global.common.exception.DomainRuleException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.*;
@@ -12,7 +13,7 @@ import lombok.*;
 @AllArgsConstructor
 @Getter
 @Builder
-public class BankAccount {
+public class BankAccount extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/BankAccount.java
@@ -27,7 +27,7 @@ public class BankAccount {
     @Column(length = 30, nullable = false)
     private String accountNumber;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/ChatTemplate.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/ChatTemplate.java
@@ -1,7 +1,7 @@
-package konkuk.chacall.domain.user.owner.domain;
+package konkuk.chacall.domain.owner.domain.model;
 
 import jakarta.persistence.*;
-import konkuk.chacall.domain.user.User;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -3,5 +3,10 @@ package konkuk.chacall.domain.owner.domain.repository;
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface BankAccountRepository extends JpaRepository<Long, BankAccount> {
+import java.util.List;
+import java.util.Optional;
+
+public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
+
+    boolean existsByOwner_UserIdAndAccountNumber(Long userId, String accountNumber);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -3,10 +3,9 @@ package konkuk.chacall.domain.owner.domain.repository;
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
 public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
 
-    boolean existsByOwner_UserIdAndAccountNumber(Long userId, String accountNumber);
+    boolean existsByAccountNumber(String accountNumber);
+
+    boolean existsByOwner_UserId(Long userId);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -2,6 +2,8 @@ package konkuk.chacall.domain.owner.domain.repository;
 
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
@@ -14,8 +16,6 @@ public interface BankAccountRepository extends JpaRepository<BankAccount, Long> 
     boolean existsByOwner_UserId(Long userId);
 
     // 사장님 ID 기반 계좌 조회
-    Optional<BankAccount> findByOwner_UserId(Long userId);
-
-    // 계좌 ID와 사장님 ID로 계좌 조회
-    Optional<BankAccount> findByBankAccountIdAndOwner_UserId(Long bankAccountId, Long ownerId);
+    @Query("SELECT ba FROM BankAccount ba WHERE ba.owner.userId = :ownerId")
+    Optional<BankAccount> findByOwnerId(@Param("ownerId") Long ownerId);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -15,4 +15,7 @@ public interface BankAccountRepository extends JpaRepository<BankAccount, Long> 
 
     // 사장님 ID 기반 계좌 조회
     Optional<BankAccount> findByOwner_UserId(Long userId);
+
+    // 계좌 ID와 사장님 ID로 계좌 조회
+    Optional<BankAccount> findByBankAccountIdAndOwner_UserId(Long bankAccountId, Long ownerId);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -3,9 +3,16 @@ package konkuk.chacall.domain.owner.domain.repository;
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BankAccountRepository extends JpaRepository<BankAccount, Long> {
 
+    // 계좌 번호가 DB 상에 이미 존재하는지 여부 조회
     boolean existsByAccountNumber(String accountNumber);
 
+    // 사장님 ID 기반 계좌 등록 여부 조회
     boolean existsByOwner_UserId(Long userId);
+
+    // 사장님 ID 기반 계좌 조회
+    Optional<BankAccount> findByOwner_UserId(Long userId);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/BankAccountRepository.java
@@ -1,0 +1,7 @@
+package konkuk.chacall.domain.owner.domain.repository;
+
+import konkuk.chacall.domain.owner.domain.model.BankAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BankAccountRepository extends JpaRepository<Long, BankAccount> {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -1,4 +1,30 @@
 package konkuk.chacall.domain.owner.presentation;
 
+import jakarta.validation.Valid;
+import konkuk.chacall.domain.owner.application.OwnerService;
+import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import konkuk.chacall.global.common.dto.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/owners")
+@Slf4j
 public class OwnerController {
+
+    private final OwnerService ownerService;
+
+    @PostMapping("/me/bank-accounts")
+    public BaseResponse<Void> registerBankAccount(
+            @Valid RegisterBankAccountRequest registerBankAccountRequest
+    ) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.registerBankAccount(registerBankAccountRequest, 1L);
+
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -42,4 +42,13 @@ public class OwnerController {
         ownerService.updateBankAccount(1L, bankAccountId, request);
         return BaseResponse.ok(null);
     }
+
+    @DeleteMapping("/me/bank-accounts/{bankAccountId}")
+    public BaseResponse<Void> deleteBankAccount(
+            @PathVariable Long bankAccountId
+    ) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.deleteBankAccount(1L, bankAccountId);
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -38,7 +38,6 @@ public class OwnerController {
     public BaseResponse<Void> updateBankAccount(
             @PathVariable Long bankAccountId,
             @RequestBody @Valid UpdateBankAccountRequest request) {
-
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
         ownerService.updateBankAccount(1L, bankAccountId, request);
         return BaseResponse.ok(null);

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -2,10 +2,12 @@ package konkuk.chacall.domain.owner.presentation;
 
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
-import konkuk.chacall.domain.owner.presentation.dto.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -26,5 +28,11 @@ public class OwnerController {
         ownerService.registerBankAccount(registerBankAccountRequest, 1L);
 
         return BaseResponse.ok(null);
+    }
+
+    @GetMapping("/me/bank-accounts")
+    public BaseResponse<BankAccountResponse> getBankAccount() {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        return BaseResponse.ok(ownerService.getBankAccount(1L));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -1,0 +1,4 @@
+package konkuk.chacall.domain.owner.presentation;
+
+public class OwnerController {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -20,7 +20,7 @@ public class OwnerController {
 
     @PostMapping("/me/bank-accounts")
     public BaseResponse<Void> registerBankAccount(
-            @Valid RegisterBankAccountRequest registerBankAccountRequest
+            @RequestBody @Valid RegisterBankAccountRequest registerBankAccountRequest
     ) {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
         ownerService.registerBankAccount(registerBankAccountRequest, 1L);

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -3,14 +3,12 @@ package konkuk.chacall.domain.owner.presentation;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -34,5 +32,15 @@ public class OwnerController {
     public BaseResponse<BankAccountResponse> getBankAccount() {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
         return BaseResponse.ok(ownerService.getBankAccount(1L));
+    }
+
+    @PatchMapping("/me/bank-accounts/{bankAccountId}")
+    public BaseResponse<Void> updateBankAccount(
+            @PathVariable Long bankAccountId,
+            @RequestBody @Valid UpdateBankAccountRequest request) {
+
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.updateBankAccount(1L, bankAccountId, request);
+        return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/RegisterBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/RegisterBankAccountRequest.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.domain.owner.presentation.dto;
+
+public record RegisterBankAccountRequest(
+        String bankName,
+        String accountHolderName,
+        String accountNumber
+) {
+    public static RegisterBankAccountRequest of(
+            String bankName,
+            String accountHolderName,
+            String accountNumber
+    ) {
+        return new RegisterBankAccountRequest(bankName, accountHolderName, accountNumber);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/RegisterBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/RegisterBankAccountRequest.java
@@ -1,15 +1,15 @@
 package konkuk.chacall.domain.owner.presentation.dto;
 
+import jakarta.validation.constraints.NotBlank;
+
 public record RegisterBankAccountRequest(
+        @NotBlank(message = "은행명을 입력해야 합니다.")
         String bankName,
+
+        @NotBlank(message = "예금주명을 입력해야 합니다.")
         String accountHolderName,
+
+        @NotBlank(message = "계좌번호를 입력해야 합니다.")
         String accountNumber
 ) {
-    public static RegisterBankAccountRequest of(
-            String bankName,
-            String accountHolderName,
-            String accountNumber
-    ) {
-        return new RegisterBankAccountRequest(bankName, accountHolderName, accountNumber);
-    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterBankAccountRequest.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.owner.presentation.dto;
+package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateBankAccountRequest.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateBankAccountRequest(
+        @NotBlank(message = "은행명은 비어있을 수 없습니다.")
+        String bankName,
+
+        @NotBlank(message = "예금주명은 비어있을 수 없습니다.")
+        String accountHolderName,
+
+        @NotBlank(message = "계좌번호는 비어있을 수 없습니다.")
+        String accountNumber
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/BankAccountResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/BankAccountResponse.java
@@ -1,0 +1,18 @@
+package konkuk.chacall.domain.owner.presentation.dto.response;
+
+import konkuk.chacall.domain.owner.domain.model.BankAccount;
+
+public record BankAccountResponse(
+        Long bankAccountId,
+        String bankName,
+        String accountHolderName,
+        String accountNumber
+) {
+    public static BankAccountResponse from(BankAccount bankAccount) {
+        return new BankAccountResponse(
+                bankAccount.getBankAccountId(),
+                bankAccount.getBankName(),
+                bankAccount.getAccountHolderName(),
+                bankAccount.getAccountNumber());
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/Gender.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/Gender.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.user;
+package konkuk.chacall.domain.user.domain.model;
 
 import lombok.Getter;
 

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/Role.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/Role.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.user;
+package konkuk.chacall.domain.user.domain.model;
 
 import lombok.Getter;
 

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
@@ -3,10 +3,12 @@ package konkuk.chacall.domain.user.domain.model;
 import jakarta.persistence.*;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "users")
+@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User extends BaseEntity {
 

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.user;
+package konkuk.chacall.domain.user.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.global.common.domain.BaseEntity;

--- a/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package konkuk.chacall.domain.user.domain.repository;
+
+import konkuk.chacall.domain.user.domain.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<Long, User> {
+}

--- a/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
@@ -10,4 +10,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByUserIdAndRoleAndStatus(Long userId, Role role, BaseStatus status);
+
+    boolean existsByUserIdAndRoleAndStatus(Long userId, Role role, BaseStatus status);
 }

--- a/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
@@ -1,7 +1,12 @@
 package konkuk.chacall.domain.user.domain.repository;
 
+import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserRepository extends JpaRepository<Long, User> {
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByUserIdAndRole(Long id, Role role);
 }

--- a/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
@@ -2,11 +2,12 @@ package konkuk.chacall.domain.user.domain.repository;
 
 import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.domain.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-    Optional<User> findByUserIdAndRole(Long id, Role role);
+    Optional<User> findByUserIdAndRoleAndStatus(Long userId, Role role, BaseStatus status);
 }

--- a/src/main/java/konkuk/chacall/domain/user/member/application/MemberService.java
+++ b/src/main/java/konkuk/chacall/domain/user/member/application/MemberService.java
@@ -1,4 +1,0 @@
-package konkuk.chacall.domain.user.member.application;
-
-public class MemberService {
-}

--- a/src/main/java/konkuk/chacall/domain/user/member/presentation/MemberController.java
+++ b/src/main/java/konkuk/chacall/domain/user/member/presentation/MemberController.java
@@ -1,4 +1,0 @@
-package konkuk.chacall.domain.user.member.presentation;
-
-public class MemberController {
-}

--- a/src/main/java/konkuk/chacall/domain/user/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/user/owner/application/OwnerService.java
@@ -1,4 +1,0 @@
-package konkuk.chacall.domain.user.owner.application;
-
-public class OwnerService {
-}

--- a/src/main/java/konkuk/chacall/domain/user/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/user/owner/presentation/OwnerController.java
@@ -1,4 +1,0 @@
-package konkuk.chacall.domain.user.owner.presentation;
-
-public class OwnerController {
-}

--- a/src/main/java/konkuk/chacall/global/common/annotation/HelperService.java
+++ b/src/main/java/konkuk/chacall/global/common/annotation/HelperService.java
@@ -1,0 +1,14 @@
+package konkuk.chacall.global.common.annotation;
+
+import org.springframework.stereotype.Service;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Service
+public @interface HelperService {
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -36,7 +36,8 @@ public enum ErrorCode implements ResponseCode {
      * BankAccount
      */
     BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 70001, "계좌를 찾을 수 없습니다."),
-    BANK_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, 70002, "이미 존재하는 계좌입니다.")
+    BANK_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, 70002, "이미 존재하는 계좌입니다."),
+    BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER(HttpStatus.CONFLICT, 70003, "해당 유저에게 이미 등록된 계좌가 존재합니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -32,6 +32,11 @@ public enum ErrorCode implements ResponseCode {
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, 60002, "이미 존재하는 사용자입니다."),
     USER_NICKNAME_DUPLICATION(HttpStatus.CONFLICT, 60003, "이미 존재하는 닉네임입니다."),
 
+    /**
+     * BankAccount
+     */
+    BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 70001, "계좌를 찾을 수 없습니다."),
+    BANK_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, 70002, "이미 존재하는 계좌입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -37,7 +37,8 @@ public enum ErrorCode implements ResponseCode {
      */
     BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 70001, "계좌를 찾을 수 없습니다."),
     BANK_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, 70002, "이미 존재하는 계좌입니다."),
-    BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER(HttpStatus.CONFLICT, 70003, "해당 유저에게 이미 등록된 계좌가 존재합니다.")
+    BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER(HttpStatus.CONFLICT, 70003, "해당 유저에게 이미 등록된 계좌가 존재합니다."),
+    BANK_ACCOUNT_FORBIDDEN(HttpStatus.CONFLICT, 70004, "계좌에 대한 권한이 없습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## #️⃣연관된 이슈
> closes #3 

## 📝작업 내용

계좌 관련 CRUD 기능을 구현하였습니다.

### 계좌 등록
피그마를 확인해보니, 사장님 한 분당 하나의 계좌만 등록할 수 있도록 요구사항이 변경된 것을 확인할 수 있었습니다.
따라서 User <-> BankAccount 간의 연관관계를 OneToOne 으로 변경하고, 외래키는 여전히 BankAccount 쪽에서 가지고있도록 구현을 변경하였습니다.

계좌 등록시 검증해주어야할 사항이 몇가지 존재했고, 그 항목들은 다음과 같습니다.

1. **`계좌 등록을 요청한 사람이 DB 상에 존재하는지 && 사장님인지 && status = ACTIVE 인지`**
2. **`이미 등록된 계좌가 존재하지는 않는지`**
3. **`이미 등록된 계좌가 없다고 하더라도, 등록하고자 하는 계좌를 다른 어떤 사장님이 사용하고있지는 않은지`**

### 계좌 조회

계좌 조회에서 유의해야했던 점은, 계좌가 등록되어있지 않은 상황을 에러로 판단하지 않는다는 점이었습니다.
최초로 가입한 후, 혹은 등록해뒀던 계좌를 삭제한 후에는 특정 사장님에 대해서 계좌가 존재하지 않는 경우가 존재할 수 있었습니다.
또한 계좌 등록 여부에 따라 결제 관리 뷰에서 '수정하기' 버튼을 비활성화 하느냐 마느냐를 결정해야했기 때문에, 계좌가 등록되어있지 않다면 계좌 조회시 null 응답을 반환하도록 하고, 계좌가 등록되어있다면 데이터가 정상적으로 반환되도록 구현하였습니다.

### 계좌 수정
계좌 수정은 사실상 계좌 등록과 동일했습니다. 계좌 등록 때처럼 은행명, 예금주명, 계좌 번호를 모두 입력받도록 구현하였고, 그렇게 받은 값들을 기반으로 JPA 변경 감지 기능을 활용하여 수정되도록 구현하였습니다.

계좌 수정 및 삭제 시에는 동일한 케이스를 검증하게 되는데, 수정 혹은 삭제하고자 하는 계좌가 본인의 명의가 맞는지, 즉 소유주가 본인이 맞는지를 검증하게됩니다.

### 계좌 삭제
위에 언급한 것처럼 삭제하고자하는 계좌가 본인의 명의인지를 검증 후 삭제를 진행합니다.

### 공통 처리 로직
사장님 관련 로직들을 작성할 때는 해당 요청을 보낸 사용자가 DB에 존재하는지, 사장님인지, status = ACTIVE 인지를 매번 검증해주도록 하였습니다. 일반유저 ROLE 을 가지고 사장님 관련 API 로 요청을 보내는 케이스를 방지하기 위함입니다.

다만 각각의 기능마다 사장님인지를 검증하는 로직이 들어가야하다보니 모든 메서드에 중복된 로직이 들어가야했고, 계좌 관련 서비스 로직에서 불필요하게 유저 검증 로직을 함께 담당하는 문제점이 존재했습니다.
따라서 owner/application 하위에 util 패키지를 만들고, 해당 패키지 내부에 사장님 여부를 검증해주는 별도의 헬퍼클래스를 구현하여 중복된 로직을 처리해줄 수 있도록 하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

1. 현재 요청 DTO = ~~~Request / 응답 DTO = ~~~Response 와 같이 네이밍을 해두었는데, 이처럼 요청 DTO / 응답 DTO 클래스에 대한 네이밍을 통일시키면 좋을 것 같습니다.

2. 헬퍼클래스를 구현할 위치를 어디로 지정하면 좋을지 논의해보면 좋을 것 같습니다. 
지금은 일단 실제 서비스 로직들을 담당하는 application 패키지의 하위에 util 이라는 패키지를 만든 후 그 내부에 헬퍼 클래스를 구현하였습니다.
다만 약간 마음에 안드는 점이, 현재 저는 `특정 도메인/application` 하위에 해당 도메인에 대한 파사드 서비스를 하나 만들어둔 상태입니다.
또한 파사드 내부에서 조립하여 쓸, 각각의 특화 기능 (ex) 계좌 / 자주쓰는 채팅 / 나의 푸드트럭 ) 들을 위한 패키지(ex) bankAccount) 를 별도로 만들어주었습니다. 
<img width="203" height="119" alt="스크린샷 2025-09-14 오전 2 32 28" src="https://github.com/user-attachments/assets/48c0469b-7642-456b-ba43-fd9d8cc83abf" />

그러다보니 실제 서비스 로직을 담당하는 패키지들과 util 패키지가 뒤섞여버려서 이 부분이 좀 마음에 들지 않더라구요. 그래서 이 부분에 대해 이야기해보고 싶습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 점주용 계좌 관리 API 추가: 등록, 조회, 수정, 삭제 지원 (/owners/me/bank-accounts).
  - 계좌 응답/요청 DTO 제공 및 입력값 유효성 검증(국문 메시지) 강화.
- 개선
  - 계좌 미존재, 중복, 권한 오류 등 계좌 관련 에러 코드 추가로 오류 응답 명확화.
- 리팩터링
  - 도메인 구조 정리 및 일관된 사용자 참조로 내부 구조를 개선하여 유지보수성 향상.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->