### PR TITLE
[DOCS] Swagger 명세 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,9 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.8'
 }
 
 tasks.named('test') {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -1,15 +1,24 @@
 package konkuk.chacall.domain.owner.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
+import konkuk.chacall.global.common.annotation.ExceptionDescription;
+import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.web.bind.annotation.*;
 
+@Tag(name = "Owner API", description = "사장님 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/owners")
@@ -18,37 +27,59 @@ public class OwnerController {
 
     private final OwnerService ownerService;
 
+    @Operation(
+            summary = "은행 계좌 등록",
+            description = "사장님이 자신의 은행 계좌를 등록합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_REGISTER_BANK_ACCOUNT)
     @PostMapping("/me/bank-accounts")
     public BaseResponse<Void> registerBankAccount(
-            @RequestBody @Valid RegisterBankAccountRequest registerBankAccountRequest
+            @RequestBody @Valid final RegisterBankAccountRequest registerBankAccountRequest,
+            @Parameter(hidden = true) @UserId final Long ownerId
     ) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.registerBankAccount(registerBankAccountRequest, 1L);
+        ownerService.registerBankAccount(registerBankAccountRequest, ownerId);
 
         return BaseResponse.ok(null);
     }
 
+    @Operation(
+            summary = "은행 계좌 조회",
+            description = "사장님이 자신의 은행 계좌를 조회합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_GET_BANK_ACCOUNT)
     @GetMapping("/me/bank-accounts")
-    public BaseResponse<BankAccountResponse> getBankAccount() {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        return BaseResponse.ok(ownerService.getBankAccount(1L));
+    public BaseResponse<BankAccountResponse> getBankAccount(
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(ownerService.getBankAccount(ownerId));
     }
 
+    @Operation(
+            summary = "은행 계좌 수정",
+            description = "사장님이 자신의 은행 계좌를 수정합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_BANK_ACCOUNT)
     @PatchMapping("/me/bank-accounts/{bankAccountId}")
     public BaseResponse<Void> updateBankAccount(
-            @PathVariable Long bankAccountId,
-            @RequestBody @Valid UpdateBankAccountRequest request) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.updateBankAccount(1L, bankAccountId, request);
+            @PathVariable final Long bankAccountId,
+            @RequestBody @Valid final UpdateBankAccountRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+            ) {
+        ownerService.updateBankAccount(ownerId, bankAccountId, request);
         return BaseResponse.ok(null);
     }
 
+    @Operation(
+            summary = "은행 계좌 삭제",
+            description = "사장님이 자신의 은행 계좌를 삭제합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_DELETE_BANK_ACCOUNT)
     @DeleteMapping("/me/bank-accounts/{bankAccountId}")
     public BaseResponse<Void> deleteBankAccount(
-            @PathVariable Long bankAccountId
+            @PathVariable final Long bankAccountId,
+            @Parameter(hidden = true) @UserId final Long ownerId
     ) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.deleteBankAccount(1L, bankAccountId);
+        ownerService.deleteBankAccount(ownerId, bankAccountId);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterBankAccountRequest.java
@@ -1,14 +1,19 @@
 package konkuk.chacall.domain.owner.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "은행 계좌 등록 요청 DTO")
 public record RegisterBankAccountRequest(
+        @Schema(description = "은행명", example = "국민은행")
         @NotBlank(message = "은행명을 입력해야 합니다.")
         String bankName,
 
+        @Schema(description = "예금주명", example = "홍길동")
         @NotBlank(message = "예금주명을 입력해야 합니다.")
         String accountHolderName,
 
+        @Schema(description = "계좌번호", example = "123-456-78901234")
         @NotBlank(message = "계좌번호를 입력해야 합니다.")
         String accountNumber
 ) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateBankAccountRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateBankAccountRequest.java
@@ -1,14 +1,19 @@
 package konkuk.chacall.domain.owner.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
+@Schema(description = "은행 계좌 수정 요청 DTO")
 public record UpdateBankAccountRequest(
+        @Schema(description = "은행명", example = "국민은행")
         @NotBlank(message = "은행명은 비어있을 수 없습니다.")
         String bankName,
 
+        @Schema(description = "예금주명", example = "홍길동")
         @NotBlank(message = "예금주명은 비어있을 수 없습니다.")
         String accountHolderName,
 
+        @Schema(description = "계좌번호", example = "123-456-78901234")
         @NotBlank(message = "계좌번호는 비어있을 수 없습니다.")
         String accountNumber
 ) {

--- a/src/main/java/konkuk/chacall/domain/test/TestController.java
+++ b/src/main/java/konkuk/chacall/domain/test/TestController.java
@@ -11,8 +11,10 @@ import konkuk.chacall.global.common.exception.DomainRuleException;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.Getter;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.bind.annotation.*;
 
+@Profile("local")
 @RestController
 @RequestMapping("/test")
 public class TestController {

--- a/src/main/java/konkuk/chacall/global/common/annotation/ExceptionDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/annotation/ExceptionDescription.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.global.common.annotation;
+
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExceptionDescription {
+
+    SwaggerResponseDescription value();
+}

--- a/src/main/java/konkuk/chacall/global/common/annotation/UserId.java
+++ b/src/main/java/konkuk/chacall/global/common/annotation/UserId.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.global.common.security.annotation;
+package konkuk.chacall.global.common.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/konkuk/chacall/global/common/security/oauth2/auth/AuthController.java
+++ b/src/main/java/konkuk/chacall/global/common/security/oauth2/auth/AuthController.java
@@ -1,13 +1,17 @@
 package konkuk.chacall.global.common.security.oauth2.auth;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import konkuk.chacall.global.common.exception.AuthException;
 import konkuk.chacall.global.common.security.oauth2.tokenstorage.LoginTokenStorage;
 import konkuk.chacall.global.common.security.oauth2.auth.dto.AuthTokenRequest;
 import konkuk.chacall.global.common.security.oauth2.auth.dto.AuthTokenResponse;
 import konkuk.chacall.global.common.security.util.JwtUtil;
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -17,13 +21,11 @@ import org.springframework.web.bind.annotation.RestController;
 import static konkuk.chacall.global.common.exception.code.ErrorCode.API_INVALID_PARAM;
 import static konkuk.chacall.global.common.exception.code.ErrorCode.AUTH_INVALID_LOGIN_TOKEN_KEY;
 
+@Tag(name = "Auth API", description = "인증 관련 API")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/auth")
 public class AuthController {
-
-    private final UserRepository userRepository;
-    private final JwtUtil jwtUtil;
 
     private final LoginTokenStorage loginTokenStorage;
 
@@ -31,6 +33,9 @@ public class AuthController {
      * loginTokenKey를 받아서, 해당 토큰이 유효한지 확인 후,
      * 유효하다면 JWT Access Token을 발급하여 응답으로 반환합니다.
      */
+    @Operation(summary = "JWT Access Token 발급", description = "loginTokenKey를 통해 JWT Access Token을 발급받습니다." +
+            " 카카오 소셜 로그인 직후 리다이렉트 url의 쿼리 파라미터에서 loginTokenKey를 꺼내서 요청해주세요.")
+    @ExceptionDescription(SwaggerResponseDescription.LOGOUT)
     @PostMapping("/token")
     public BaseResponse<AuthTokenResponse> getToken(
             @RequestBody @Valid AuthTokenRequest request

--- a/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
+++ b/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
@@ -2,7 +2,7 @@ package konkuk.chacall.global.common.security.resolver;
 
 import jakarta.servlet.http.HttpServletRequest;
 import konkuk.chacall.global.common.exception.AuthException;
-import konkuk.chacall.global.common.security.annotation.UserId;
+import konkuk.chacall.global.common.annotation.UserId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;

--- a/src/main/java/konkuk/chacall/global/common/swagger/ExampleHolder.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/ExampleHolder.java
@@ -1,0 +1,14 @@
+package konkuk.chacall.global.common.swagger;
+
+import io.swagger.v3.oas.models.examples.Example;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ExampleHolder {
+
+    private Example holder;
+    private String name;
+    private int code;
+}

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -18,6 +18,10 @@ public enum SwaggerResponseDescription {
     LOGOUT(new LinkedHashSet<>(Set.of(
 
     ))),
+    ISSUE_TOKEN(new LinkedHashSet<>(Set.of(
+            AUTH_INVALID_LOGIN_TOKEN_KEY,
+            USER_NOT_FOUND
+    ))),
 
     // Owner
     OWNER_REGISTER_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -19,6 +19,26 @@ public enum SwaggerResponseDescription {
 
     ))),
 
+    // Owner
+    OWNER_REGISTER_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER,
+            BANK_ACCOUNT_ALREADY_EXISTS
+    ))),
+    OWNER_GET_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
+    ))),
+    OWNER_UPDATE_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            BANK_ACCOUNT_NOT_FOUND,
+            BANK_ACCOUNT_ALREADY_EXISTS,
+            BANK_ACCOUNT_FORBIDDEN
+    ))),
+    OWNER_DELETE_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            BANK_ACCOUNT_NOT_FOUND,
+            BANK_ACCOUNT_FORBIDDEN
+    ))),
+
   ;
     private final Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -1,0 +1,39 @@
+package konkuk.chacall.global.common.swagger;
+
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.Getter;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+import static konkuk.chacall.global.common.exception.code.ErrorCode.*;
+
+@Getter
+public enum SwaggerResponseDescription {
+//
+    //Auth
+    LOGIN(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    LOGOUT(new LinkedHashSet<>(Set.of(
+
+    ))),
+
+  ;
+    private final Set<ErrorCode> errorCodeList;
+    SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
+        // 공통 에러
+        errorCodeList.addAll(new LinkedHashSet<>(Set.of(
+                API_NOT_FOUND,
+                API_METHOD_NOT_ALLOWED,
+                API_SERVER_ERROR,
+
+                API_MISSING_PARAM,
+                API_INVALID_PARAM,
+                API_INVALID_TYPE
+        )));
+
+
+        this.errorCodeList = errorCodeList;
+    }
+}

--- a/src/main/java/konkuk/chacall/global/config/OpenApiConfig.java
+++ b/src/main/java/konkuk/chacall/global/config/OpenApiConfig.java
@@ -1,0 +1,145 @@
+package konkuk.chacall.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import konkuk.chacall.global.common.annotation.ExceptionDescription;
+import konkuk.chacall.global.common.dto.ErrorResponse;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import konkuk.chacall.global.common.swagger.ExampleHolder;
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static java.util.stream.Collectors.groupingBy;
+
+@OpenAPIDefinition(
+        info = @Info(
+                title = "ChaCall 백엔드 API 명세서",
+                description = "Springdoc을 이용한 ChaCall Swagger API 문서입니다.",
+                version = "1.0.0"
+        )
+)
+@Configuration
+public class OpenApiConfig {
+    private final String securitySchemaName = "JWT";
+
+    @Value("${server.http-url}") private String httpUrl;
+
+    @Value(("${server.profile}")) private String profile;
+
+    @Bean
+    public OpenAPI openAPI() {
+        List<Server> serverList = switch (profile) {
+            case "dev" -> List.of(
+                    new Server().url(httpUrl).description("HTTP 개발 서버"),
+                    new Server().url("http://localhost:8080").description("로컬 개발 서버")
+            );
+            default -> List.of(
+                    new Server().url("http://localhost:8080").description("로컬 개발 서버")
+            );
+        };
+
+        return new OpenAPI()
+                .servers(serverList)
+                .components(setComponents())
+                .addSecurityItem(setSecurityItems());
+    }
+    private Components setComponents() {
+        return new Components()
+                .addSecuritySchemes(securitySchemaName, bearerAuth());
+    }
+
+    private SecurityScheme bearerAuth() {
+        return new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat(securitySchemaName)
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+    }
+
+    private SecurityRequirement setSecurityItems() {
+        return new SecurityRequirement()
+                .addList(securitySchemaName);
+    }
+
+    @Bean
+    public OperationCustomizer customize() {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+
+            ExceptionDescription exceptionDescription = handlerMethod.getMethodAnnotation(
+                    ExceptionDescription.class);
+
+            // ExceptionDescription 어노테이션 단 메소드 적용
+            if (exceptionDescription != null) {
+                generateErrorCodeResponseExample(operation, exceptionDescription.value());
+            }
+
+            return operation;
+        };
+    }
+    private void generateErrorCodeResponseExample(
+            Operation operation, SwaggerResponseDescription type) {
+
+        ApiResponses responses = operation.getResponses();
+
+        Set<ErrorCode> errorCodeList = type.getErrorCodeList();
+
+        Map<Integer, List<ExampleHolder>> statusWithExampleHolders =
+                errorCodeList.stream()
+                        .map(
+                                errorCode -> ExampleHolder.builder()
+                                        .holder(getSwaggerExample(errorCode))
+                                        .code(errorCode.getHttpStatus().value())
+                                        .name(errorCode.toString())
+                                        .build()
+                        ).collect(groupingBy(ExampleHolder::getCode));
+        addExamplesToResponses(responses, statusWithExampleHolders);
+    }
+
+    private Example getSwaggerExample(ErrorCode errorCode) {
+        ErrorResponse errorResponse = ErrorResponse.of(errorCode);
+        Example example = new Example();
+        example.description(errorCode.getMessage());
+        example.setValue(errorResponse);
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses, Map<Integer, List<ExampleHolder>> statusWithExampleHolders) {
+        statusWithExampleHolders.forEach(
+                (status, v) -> {
+                    Content content = new Content();
+                    MediaType mediaType = new MediaType();
+                    ApiResponse apiResponse = new ApiResponse();
+                    v.forEach(
+                            exampleHolder -> {
+                                mediaType.addExamples(
+                                        exampleHolder.getName(), exampleHolder.getHolder());
+                            });
+                    content.addMediaType("application/json", mediaType);
+                    apiResponse.setDescription("");
+                    apiResponse.setContent(content);
+                    responses.addApiResponse(status.toString(), apiResponse);
+                });
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -37,6 +37,8 @@ spring:
 ---
 server:
   port: 8000
+  profile: dev
+  http-url: ${HTTP_URL}
   web-domain-urls:
     - "http://localhost:5173"
     - "https://chacall.co.kr"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,6 +38,8 @@ spring:
 ---
 server:
   port: 8080
+  profile: local
+  http-url: ${HTTP_URL}
   web-domain-urls:
     - "http://localhost:5173"
     - "https://chacall.co.kr"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,7 @@ logging:
 ---
 server:
   port: 8080
+  profile: test
   http-url: http://localhost:8080
   web-domain-urls:
     - "http://localhost:5173"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -32,6 +32,7 @@ logging:
 ---
 server:
   port: 8080
+  http-url: http://localhost:8080
   web-domain-urls:
     - "http://localhost:5173"
     - "https://chacall.co.kr"


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #8 

## 📝작업 내용

스웨거 명세 의존성을 추가했습니다.

상균님이 구현하신 사장님 계좌 관련 crud api도 제가 임의로 명세하긴 했는데 구체적인 api 설명에 관해서는 상균님이 덧붙여주시면 감사하겠습니다~

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - Swagger/OpenAPI UI 제공으로 인터랙티브 API 문서 사용 가능
  - JWT Bearer 인증 스키마 지원 및 전역 보안 적용
  - 오류 사례 자동 예시 생성으로 응답 예시 강화

- 개선
  - 점주 계좌 API가 로그인된 사용자 컨텍스트에 연동되어 동작
  - 인증 API에 태그/설명 추가로 문서 가독성 향상

- 설정
  - dev/local/test 프로필에 server.profile·server.http-url 설정 추가
  - 테스트 전용 컨트롤러는 local 프로필에서만 활성화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->