### PR TITLE
[FEAT] 사장님 - 자주 쓰는 채팅 CRUD 기능 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,8 +1,10 @@
 package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
+import konkuk.chacall.domain.owner.application.chatTemplate.ChatTemplateService;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.user.domain.model.User;
@@ -14,7 +16,9 @@ import org.springframework.stereotype.Service;
 public class OwnerService {
 
     private final BankAccountService bankAccountService;
-    // 파사드에서 사장님 검증을 거침으로써 실제 계좌 관련 서비스 로직에서는 사장님 검증에 신경쓰지 않도록 책임 분리
+    private final ChatTemplateService chatTemplateService;
+
+    // 파사드에서 사장님 검증을 거침으로써 서비스 로직에서는 사장님 검증에 신경쓰지 않도록 책임 분리
     private final OwnerValidator ownerValidator;
 
     public void registerBankAccount(RegisterBankAccountRequest request, Long ownerId) {
@@ -47,6 +51,15 @@ public class OwnerService {
 
         // 계좌 삭제 로직 호출
         bankAccountService.deleteBankAccount(ownerId, bankAccountId);
+    }
+
+
+    public void registerChatTemplate(RegisterChatTemplateRequest request, Long ownerId) {
+        // 사장님인지 먼저 검증
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        // 자주 쓰는 채팅 등록 로직 호출
+        chatTemplateService.registerChatTemplate(request, owner);
     }
 
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -7,9 +7,12 @@ import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountR
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -60,6 +63,14 @@ public class OwnerService {
 
         // 자주 쓰는 채팅 등록 로직 호출
         chatTemplateService.registerChatTemplate(request, owner);
+    }
+
+    public List<ChatTemplateResponse> getChatTemplates(Long ownerId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 자주 쓰는 채팅 목록 조회 로직 호출
+        return chatTemplateService.getChatTemplates(ownerId);
     }
 
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -6,6 +6,7 @@ import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.domain.user.domain.model.User;
@@ -73,4 +74,19 @@ public class OwnerService {
         return chatTemplateService.getChatTemplates(ownerId);
     }
 
+    public void updateChatTemplate(UpdateChatTemplateRequest request, Long ownerId, Long chatTemplateId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 자주 쓰는 채팅 수정 로직 호출
+        chatTemplateService.updateChatTemplate(request, chatTemplateId);
+    }
+
+    public void deleteChatTemplate(Long ownerId, Long chatTemplateId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 자주 쓰는 채팅 삭제 로직 호출
+        chatTemplateService.deleteChatTemplate(chatTemplateId);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
@@ -30,7 +30,7 @@ public class ChatTemplateService {
     }
 
     public List<ChatTemplateResponse> getChatTemplates(Long ownerId) {
-        List<ChatTemplate> chatTemplateList = chatTemplateRepository.findAllByOwnerUserId(ownerId);
+        List<ChatTemplate> chatTemplateList = chatTemplateRepository.findAllByOwnerId(ownerId);
 
         return chatTemplateList.stream()
                 .map(ChatTemplateResponse::from)

--- a/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
@@ -3,8 +3,12 @@ package konkuk.chacall.domain.owner.application.chatTemplate;
 import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
 import konkuk.chacall.domain.owner.domain.repository.ChatTemplateRepository;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,4 +36,24 @@ public class ChatTemplateService {
                 .map(ChatTemplateResponse::from)
                 .toList();
     }
+
+    @Transactional
+    public void updateChatTemplate(UpdateChatTemplateRequest request, Long chatTemplateId) {
+        ChatTemplate chatTemplate = chatTemplateRepository.findById(chatTemplateId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.CHAT_TEMPLATE_NOT_FOUND));
+
+        chatTemplate.update(
+                request.content()
+        );
+    }
+
+    @Transactional
+    public void deleteChatTemplate(Long chatTemplateId) {
+        if(!chatTemplateRepository.existsById(chatTemplateId)) {
+            throw new EntityNotFoundException(ErrorCode.CHAT_TEMPLATE_NOT_FOUND);
+        }
+
+        chatTemplateRepository.deleteById(chatTemplateId);
+    }
+
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
@@ -1,0 +1,24 @@
+package konkuk.chacall.domain.owner.application.chatTemplate;
+
+import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
+import konkuk.chacall.domain.owner.domain.repository.ChatTemplateRepository;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
+import konkuk.chacall.domain.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class ChatTemplateService {
+
+    private final ChatTemplateRepository chatTemplateRepository;
+
+    @Transactional
+    public void registerChatTemplate(RegisterChatTemplateRequest request, User owner) {
+        ChatTemplate chatTemplate = ChatTemplate.of(request.content(), owner);
+
+        chatTemplateRepository.save(chatTemplate);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/chatTemplate/ChatTemplateService.java
@@ -3,10 +3,13 @@ package konkuk.chacall.domain.owner.application.chatTemplate;
 import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
 import konkuk.chacall.domain.owner.domain.repository.ChatTemplateRepository;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
+import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
@@ -20,5 +23,13 @@ public class ChatTemplateService {
         ChatTemplate chatTemplate = ChatTemplate.of(request.content(), owner);
 
         chatTemplateRepository.save(chatTemplate);
+    }
+
+    public List<ChatTemplateResponse> getChatTemplates(Long ownerId) {
+        List<ChatTemplate> chatTemplateList = chatTemplateRepository.findAllByOwnerUserId(ownerId);
+
+        return chatTemplateList.stream()
+                .map(ChatTemplateResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/model/ChatTemplate.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/model/ChatTemplate.java
@@ -3,12 +3,14 @@ package konkuk.chacall.domain.owner.domain.model;
 import jakarta.persistence.*;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Getter
 @Entity
 @Table(name = "chat_templates")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class ChatTemplate extends BaseEntity {
 
     @Id
@@ -21,4 +23,15 @@ public class ChatTemplate extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
+
+    public static ChatTemplate of(String content, User owner) {
+        return ChatTemplate.builder()
+                .content(content)
+                .owner(owner)
+                .build();
+    }
+
+    public void update(String content) {
+        this.content = content;
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
@@ -1,0 +1,7 @@
+package konkuk.chacall.domain.owner.domain.repository;
+
+import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChatTemplateRepository extends JpaRepository<ChatTemplate, Long> {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
@@ -3,5 +3,9 @@ package konkuk.chacall.domain.owner.domain.repository;
 import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ChatTemplateRepository extends JpaRepository<ChatTemplate, Long> {
+
+    List<ChatTemplate> findAllByOwnerUserId(Long ownerId);
 }

--- a/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
+++ b/src/main/java/konkuk/chacall/domain/owner/domain/repository/ChatTemplateRepository.java
@@ -2,10 +2,14 @@ package konkuk.chacall.domain.owner.domain.repository;
 
 import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface ChatTemplateRepository extends JpaRepository<ChatTemplate, Long> {
 
-    List<ChatTemplate> findAllByOwnerUserId(Long ownerId);
+    @Query("SELECT ct FROM ChatTemplate ct WHERE ct.owner.userId = :ownerId")
+    List<ChatTemplate> findAllByOwnerId(@Param("ownerId") Long ownerId);
+
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
@@ -80,6 +81,17 @@ public class OwnerController {
             @Parameter(hidden = true) @UserId final Long ownerId
     ) {
         ownerService.deleteBankAccount(ownerId, bankAccountId);
+        return BaseResponse.ok(null);
+    }
+
+
+    @PostMapping("/me/chat-templates")
+    public BaseResponse<Void> registerChatTemplate(
+            @RequestBody @Valid RegisterChatTemplateRequest request
+    ) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.registerChatTemplate(request, 1L);
+
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -8,6 +8,7 @@ import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateChatTemplateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
@@ -100,5 +101,22 @@ public class OwnerController {
     public BaseResponse<List<ChatTemplateResponse>> getChatTemplates() {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
         return BaseResponse.ok(ownerService.getChatTemplates(1L));
+    }
+
+    @PatchMapping("/me/chat-templates/{chatTemplateId}")
+    public BaseResponse<Void> updateChatTemplate(
+            @PathVariable Long chatTemplateId,
+            @RequestBody @Valid UpdateChatTemplateRequest request) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.updateChatTemplate(request, 1L, chatTemplateId);
+        return BaseResponse.ok(null);
+    }
+
+    @DeleteMapping("/me/chat-templates/{chatTemplateId}")
+    public BaseResponse<Void> deleteChatTemplate(
+            @PathVariable Long chatTemplateId) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        ownerService.deleteChatTemplate(1L, chatTemplateId);
+        return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -90,6 +90,7 @@ public class OwnerController {
             summary = "자주 쓰는 채팅 등록",
             description = "사장님이 자주 쓰는 채팅을 등록합니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_REGISTER_CHAT_TEMPLATE)
     @PostMapping("/me/chat-templates")
     public BaseResponse<Void> registerChatTemplate(
             @RequestBody @Valid final RegisterChatTemplateRequest request,
@@ -104,6 +105,7 @@ public class OwnerController {
             summary = "자주 쓰는 채팅 조회",
             description = "사장님이 자주 쓰는 채팅을 조회합니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_GET_CHAT_TEMPLATE)
     @GetMapping("/me/chat-templates")
     public BaseResponse<List<ChatTemplateResponse>> getChatTemplates(
             @Parameter(hidden = true) @UserId final Long ownerId
@@ -115,6 +117,7 @@ public class OwnerController {
             summary = "자주 쓰는 채팅 수정",
             description = "사장님이 자주 쓰는 채팅을 수정합니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_CHAT_TEMPLATE)
     @PatchMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> updateChatTemplate(
             @PathVariable final Long chatTemplateId,
@@ -129,6 +132,7 @@ public class OwnerController {
             summary = "자주 쓰는 채팅 삭제",
             description = "사장님이 자주 쓰는 채팅을 삭제합니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_DELETE_CHAT_TEMPLATE)
     @DeleteMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> deleteChatTemplate(
             @PathVariable final Long chatTemplateId,

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -21,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 
 @Tag(name = "Owner API", description = "사장님 관련 API")
-
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/owners")
@@ -87,6 +86,10 @@ public class OwnerController {
     }
 
 
+    @Operation(
+            summary = "자주 쓰는 채팅 등록",
+            description = "사장님이 자주 쓰는 채팅을 등록합니다."
+    )
     @PostMapping("/me/chat-templates")
     public BaseResponse<Void> registerChatTemplate(
             @RequestBody @Valid final RegisterChatTemplateRequest request,
@@ -97,6 +100,10 @@ public class OwnerController {
         return BaseResponse.ok(null);
     }
 
+    @Operation(
+            summary = "자주 쓰는 채팅 조회",
+            description = "사장님이 자주 쓰는 채팅을 조회합니다."
+    )
     @GetMapping("/me/chat-templates")
     public BaseResponse<List<ChatTemplateResponse>> getChatTemplates(
             @Parameter(hidden = true) @UserId final Long ownerId
@@ -104,6 +111,10 @@ public class OwnerController {
         return BaseResponse.ok(ownerService.getChatTemplates(ownerId));
     }
 
+    @Operation(
+            summary = "자주 쓰는 채팅 수정",
+            description = "사장님이 자주 쓰는 채팅을 수정합니다."
+    )
     @PatchMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> updateChatTemplate(
             @PathVariable final Long chatTemplateId,
@@ -114,6 +125,10 @@ public class OwnerController {
         return BaseResponse.ok(null);
     }
 
+    @Operation(
+            summary = "자주 쓰는 채팅 삭제",
+            description = "사장님이 자주 쓰는 채팅을 삭제합니다."
+    )
     @DeleteMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> deleteChatTemplate(
             @PathVariable final Long chatTemplateId,

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -3,7 +3,6 @@ package konkuk.chacall.domain.owner.presentation;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import io.swagger.v3.oas.annotations.tags.Tags;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
@@ -12,14 +11,16 @@ import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountReq
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
+import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.web.bind.annotation.*;
+import java.util.List;
 
 @Tag(name = "Owner API", description = "사장님 관련 API")
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/owners")
@@ -93,5 +94,11 @@ public class OwnerController {
         ownerService.registerChatTemplate(request, 1L);
 
         return BaseResponse.ok(null);
+    }
+
+    @GetMapping("/me/chat-templates")
+    public BaseResponse<List<ChatTemplateResponse>> getChatTemplates() {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        return BaseResponse.ok(ownerService.getChatTemplates(1L));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -89,34 +89,36 @@ public class OwnerController {
 
     @PostMapping("/me/chat-templates")
     public BaseResponse<Void> registerChatTemplate(
-            @RequestBody @Valid RegisterChatTemplateRequest request
+            @RequestBody @Valid final RegisterChatTemplateRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
     ) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.registerChatTemplate(request, 1L);
+        ownerService.registerChatTemplate(request, ownerId);
 
         return BaseResponse.ok(null);
     }
 
     @GetMapping("/me/chat-templates")
-    public BaseResponse<List<ChatTemplateResponse>> getChatTemplates() {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        return BaseResponse.ok(ownerService.getChatTemplates(1L));
+    public BaseResponse<List<ChatTemplateResponse>> getChatTemplates(
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(ownerService.getChatTemplates(ownerId));
     }
 
     @PatchMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> updateChatTemplate(
-            @PathVariable Long chatTemplateId,
-            @RequestBody @Valid UpdateChatTemplateRequest request) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.updateChatTemplate(request, 1L, chatTemplateId);
+            @PathVariable final Long chatTemplateId,
+            @RequestBody @Valid final UpdateChatTemplateRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        ownerService.updateChatTemplate(request, ownerId, chatTemplateId);
         return BaseResponse.ok(null);
     }
 
     @DeleteMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> deleteChatTemplate(
-            @PathVariable Long chatTemplateId) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        ownerService.deleteChatTemplate(1L, chatTemplateId);
+            @PathVariable final Long chatTemplateId,
+            @Parameter(hidden = true) @UserId final Long ownerId) {
+        ownerService.deleteChatTemplate(ownerId, chatTemplateId);
         return BaseResponse.ok(null);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
@@ -2,9 +2,11 @@ package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record RegisterChatTemplateRequest(
         @Schema(description = "자주 쓰는 채팅 내용", example = "안녕하세요. 차콜 푸드트럭입니다!")
+        @Size(max = 500, message = "최대 500자까지 입력 가능합니다.")
         @NotBlank(message = "자주 쓰는 채팅을 입력해야합니다.")
         String content
 ) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
@@ -1,2 +1,9 @@
-package konkuk.chacall.domain.owner.presentation.dto.request;public record RegisterChatTemplateRequest() {
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RegisterChatTemplateRequest(
+        @NotBlank(message = "자주 쓰는 채팅을 입력해야합니다.")
+        String content
+) {
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
@@ -1,0 +1,2 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;public record RegisterChatTemplateRequest() {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/RegisterChatTemplateRequest.java
@@ -1,8 +1,10 @@
 package konkuk.chacall.domain.owner.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record RegisterChatTemplateRequest(
+        @Schema(description = "자주 쓰는 채팅 내용", example = "안녕하세요. 차콜 푸드트럭입니다!")
         @NotBlank(message = "자주 쓰는 채팅을 입력해야합니다.")
         String content
 ) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
@@ -1,8 +1,10 @@
 package konkuk.chacall.domain.owner.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 
 public record UpdateChatTemplateRequest(
+        @Schema(description = "자주 쓰는 채팅 내용", example = "저희집은 마라탕이 맛납니다")
         @NotBlank(message = "자주 쓰는 채팅은 비어있을 수 없습니다.")
         String content
 ) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
@@ -1,0 +1,9 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record UpdateChatTemplateRequest(
+        @NotBlank(message = "자주 쓰는 채팅은 비어있을 수 없습니다.")
+        String content
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateChatTemplateRequest.java
@@ -2,9 +2,11 @@ package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record UpdateChatTemplateRequest(
         @Schema(description = "자주 쓰는 채팅 내용", example = "저희집은 마라탕이 맛납니다")
+        @Size(max = 500, message = "최대 500자까지 입력 가능합니다.")
         @NotBlank(message = "자주 쓰는 채팅은 비어있을 수 없습니다.")
         String content
 ) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/BankAccountResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/BankAccountResponse.java
@@ -1,11 +1,16 @@
 package konkuk.chacall.domain.owner.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.owner.domain.model.BankAccount;
 
 public record BankAccountResponse(
+        @Schema(description = "계좌 식별자", example = "1")
         Long bankAccountId,
+        @Schema(description = "은행명", example = "기업은행")
         String bankName,
+        @Schema(description = "예금주명", example = "홍길동")
         String accountHolderName,
+        @Schema(description = "계좌번호", example = "110-1123-123124")
         String accountNumber
 ) {
     public static BankAccountResponse from(BankAccount bankAccount) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/ChatTemplateResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/ChatTemplateResponse.java
@@ -1,9 +1,12 @@
 package konkuk.chacall.domain.owner.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
 
 public record ChatTemplateResponse(
+        @Schema(description = "자주 쓰는 채팅 식별자", example = "1")
         Long chatTemplateId,
+        @Schema(description = "자주 쓰는 채팅 내용", example = "안녕하세요. 차콜 푸드트럭입니다!")
         String content
 ) {
     public static ChatTemplateResponse from(ChatTemplate chatTemplate) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/ChatTemplateResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/ChatTemplateResponse.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.domain.owner.presentation.dto.response;
+
+import konkuk.chacall.domain.owner.domain.model.ChatTemplate;
+
+public record ChatTemplateResponse(
+        Long chatTemplateId,
+        String content
+) {
+    public static ChatTemplateResponse from(ChatTemplate chatTemplate) {
+        return new ChatTemplateResponse(
+                chatTemplate.getChatTemplateId(),
+                chatTemplate.getContent()
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -40,7 +40,12 @@ public enum ErrorCode implements ResponseCode {
     BANK_ACCOUNT_NOT_FOUND(HttpStatus.NOT_FOUND, 70001, "계좌를 찾을 수 없습니다."),
     BANK_ACCOUNT_ALREADY_EXISTS(HttpStatus.CONFLICT, 70002, "이미 존재하는 계좌입니다."),
     BANK_ACCOUNT_ALREADY_EXISTS_FOR_USER(HttpStatus.CONFLICT, 70003, "해당 유저에게 이미 등록된 계좌가 존재합니다."),
-    BANK_ACCOUNT_FORBIDDEN(HttpStatus.CONFLICT, 70004, "계좌에 대한 권한이 없습니다.")
+    BANK_ACCOUNT_FORBIDDEN(HttpStatus.CONFLICT, 70004, "계좌에 대한 권한이 없습니다."),
+
+    /**
+     * ChatTemplate
+     */
+    CHAT_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, 80001, "자주 쓰는 채팅을 찾을 수 없습니다.");
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
+++ b/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
@@ -33,7 +33,8 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
         Object userId = ((HttpServletRequest) webRequest.getNativeRequest()).getAttribute(JWT_ACCESS_TOKEN_KEY.getValue());
         if (userId == null) {
-            throw new AuthException(AUTH_TOKEN_NOT_FOUND);
+            return 1L; // 개발동안만 임시로 1L 반환
+            // throw new AuthException(AUTH_TOKEN_NOT_FOUND);
         }
         return (Long) userId;
     }

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -30,6 +30,7 @@ public enum SwaggerResponseDescription {
             BANK_ACCOUNT_ALREADY_EXISTS
     ))),
     OWNER_GET_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
     ))),
     OWNER_UPDATE_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
@@ -42,7 +43,20 @@ public enum SwaggerResponseDescription {
             BANK_ACCOUNT_NOT_FOUND,
             BANK_ACCOUNT_FORBIDDEN
     ))),
-
+    OWNER_REGISTER_CHAT_TEMPLATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    OWNER_GET_CHAT_TEMPLATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    OWNER_UPDATE_CHAT_TEMPLATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            CHAT_TEMPLATE_NOT_FOUND
+    ))),
+    OWNER_DELETE_CHAT_TEMPLATE(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            CHAT_TEMPLATE_NOT_FOUND
+    )))
   ;
     private final Set<ErrorCode> errorCodeList;
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {

--- a/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
@@ -78,10 +78,13 @@ public class SecurityConfig {
                         .userInfoEndpoint(u -> u.userService(customOAuth2UserService))
                         .successHandler(customSuccessHandler)
                 )
-                .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(WHITELIST).permitAll()
-                        .anyRequest().authenticated()
+                .authorizeHttpRequests(auth -> auth   // 개발시동안 임시로 모든 경로 허용
+                        .requestMatchers("/**").permitAll()
                 )
+//                .authorizeHttpRequests(auth -> auth
+//                        .requestMatchers(WHITELIST).permitAll()
+//                        .anyRequest().authenticated()
+//                )
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #7 

## 📝작업 내용

자주 쓰는 채팅 관련 CRUD 기능을 구현하였습니다.

이 자주 쓰는 채팅의 경우 사실상 비즈니스 로직도 존재하지 않는 CRUD 였습니다.
채팅 내역이 중복되는지를 검증할 필요도 없고, 그 외의 복잡한 검증이 필요하지 않았기에, 오직 API 접근자가 사장님인지만 검증해줄 수 있도록 하였고, 그 외의 케이스는 -> 수정 / 삭제 를 시도할 시 해당 자주 쓰는 채팅 내역이 존재하는지 여부만 검증해주었습니다.

### 스크린샷 (선택)
<img width="702" height="549" alt="스크린샷 2025-09-15 오후 3 55 57" src="https://github.com/user-attachments/assets/2cf2a91c-9fa4-44f0-9610-134ed07cc96a" />

## 💬리뷰 요구사항(선택)

개발동안은 매번 토큰을 발급받아서 사용하기 번거로울 것 같아 SecurityConfig 에서 임시로 토큰 검증 로직을 모든 API 에 대해 해제해준 상태입니다.
따라서 UserId 도 일단은 개발이 어느정도 진행된 이후에 적용하는 것이 좋을 것 같습니다!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 소유자가 “자주 쓰는 채팅” 템플릿을 등록/조회/수정/삭제할 수 있는 기능 추가
- Documentation
  - 템플릿/계좌 응답 및 요청에 예시·설명 추가로 API 문서 강화
  - 관련 오류 코드와 응답 스펙 보강(CHAT_TEMPLATE_NOT_FOUND 등)
- Chores
  - 개발 편의를 위해 인증을 임시 완화(모든 경로 접근 허용)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->