### PR TITLE
[FEAT] 사용자 마이페이지 정보 조회/수정 api 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/user/application/UserService.java
+++ b/src/main/java/konkuk/chacall/domain/user/application/UserService.java
@@ -1,0 +1,33 @@
+package konkuk.chacall.domain.user.application;
+
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import konkuk.chacall.domain.user.presentation.dto.response.GetUserInfoResponse;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    public GetUserInfoResponse getUserInfo(Long userId) {
+        return userRepository.findById(userId)
+                .map(GetUserInfoResponse::from)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+    }
+
+    @Transactional
+    public void updateUserInfo(Long userId, UpdateUserInfoRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
+
+        user.update(request.name(), request.profileImageUrl(), request.email(), request.gender(), request.termAgreed());
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/user/application/UserService.java
+++ b/src/main/java/konkuk/chacall/domain/user/application/UserService.java
@@ -3,7 +3,7 @@ package konkuk.chacall.domain.user.application;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
-import konkuk.chacall.domain.user.presentation.dto.response.GetUserInfoResponse;
+import konkuk.chacall.domain.user.presentation.dto.response.UserResponse;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -17,9 +17,9 @@ public class UserService {
 
     private final UserRepository userRepository;
 
-    public GetUserInfoResponse getUserInfo(Long userId) {
+    public UserResponse getUserInfo(Long userId) {
         return userRepository.findById(userId)
-                .map(GetUserInfoResponse::from)
+                .map(UserResponse::from)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.USER_NOT_FOUND));
     }
 

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/Gender.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/Gender.java
@@ -1,6 +1,10 @@
 package konkuk.chacall.domain.user.domain.model;
 
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.Getter;
+
+import java.util.Arrays;
 
 @Getter
 public enum Gender {
@@ -10,5 +14,17 @@ public enum Gender {
 
     Gender(String value) {
         this.value = value;
+    }
+
+    public static Gender from(String value) {
+        return Arrays.stream(Gender.values())
+                .filter(genderVal -> genderVal.getValue().equals(value.trim()))
+                .findFirst()
+                .orElseThrow(
+                        () -> new DomainRuleException(ErrorCode.USER_GENDER_MISMATCH,
+                                new IllegalArgumentException(
+                                        String.format("존재하지 않는 성별입니다. value: %s", value)
+                                ))
+                );
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/model/User.java
@@ -37,13 +37,26 @@ public class User extends BaseEntity {
     @Column(length = 15, nullable = false)
     private Role role;
 
+    // 약관 동의 여부 컬럼
+    @Column(nullable = false)
+    private boolean termsAgreed;
+
     public static User createNewUser(String name, String profileImageUrl, String kakaoId, String email) {
         return User.builder()
                 .name(name)
                 .profileImageUrl(profileImageUrl)
                 .kakaoId(kakaoId)
                 .email(email)
+                .termsAgreed(false)
                 .role(Role.NON_SELECTED)
                 .build();
+    }
+
+    public void update(String name, String profileImageUrl, String email, String genderStr, boolean termsAgreed) {
+        this.name = name;
+        this.profileImageUrl = profileImageUrl;
+        this.email = email;
+        this.gender = Gender.from(genderStr);
+        this.termsAgreed = termsAgreed;
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
 
     @Operation(summary = "[마이페이지] 회원 정보 수정", description = "사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)")
     @ExceptionDescription(SwaggerResponseDescription.UPDATE_USER_INFO)
-    @PatchMapping("/me")
+    @PutMapping("/me")
     public BaseResponse<Void> updateUserInfo(
             @RequestBody @Valid final UpdateUserInfoRequest request,
             @Parameter(hidden = true) @UserId final Long userId

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import konkuk.chacall.domain.user.application.UserService;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
 import konkuk.chacall.domain.user.presentation.dto.response.GetUserInfoResponse;
+import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.dto.BaseResponse;
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -21,6 +23,7 @@ public class UserController {
     private final UserService userService;
 
     @Operation(summary = "[마이페이지] 회원 정보 조회", description = "사용자(고객)의 정보를 조회합니다. (사장님, 일반유저 무관)")
+    @ExceptionDescription(SwaggerResponseDescription.GET_USER_INFO)
     @GetMapping("/me")
     public BaseResponse<GetUserInfoResponse> getUserInfo() {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
@@ -28,6 +31,7 @@ public class UserController {
     }
 
     @Operation(summary = "[마이페이지] 회원 정보 수정", description = "사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)")
+    @ExceptionDescription(SwaggerResponseDescription.UPDATE_USER_INFO)
     @PatchMapping("/me")
     public BaseResponse<Void> updateUserInfo(UpdateUserInfoRequest request) {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -2,17 +2,15 @@ package konkuk.chacall.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import konkuk.chacall.domain.user.application.UserService;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
-import konkuk.chacall.domain.user.presentation.dto.response.GetUserInfoResponse;
+import konkuk.chacall.domain.user.presentation.dto.response.UserResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "User API", description = "전체 사용자(마이페이지) 관련 API")
 @RestController
@@ -25,7 +23,7 @@ public class UserController {
     @Operation(summary = "[마이페이지] 회원 정보 조회", description = "사용자(고객)의 정보를 조회합니다. (사장님, 일반유저 무관)")
     @ExceptionDescription(SwaggerResponseDescription.GET_USER_INFO)
     @GetMapping("/me")
-    public BaseResponse<GetUserInfoResponse> getUserInfo() {
+    public BaseResponse<UserResponse> getUserInfo() {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
         return BaseResponse.ok(userService.getUserInfo(1L));
     }
@@ -33,7 +31,9 @@ public class UserController {
     @Operation(summary = "[마이페이지] 회원 정보 수정", description = "사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)")
     @ExceptionDescription(SwaggerResponseDescription.UPDATE_USER_INFO)
     @PatchMapping("/me")
-    public BaseResponse<Void> updateUserInfo(UpdateUserInfoRequest request) {
+    public BaseResponse<Void> updateUserInfo(
+            final @RequestBody @Valid UpdateUserInfoRequest request
+    ) {
         // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
          userService.updateUserInfo(1L, request);
 

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -1,12 +1,14 @@
 package konkuk.chacall.domain.user.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.user.application.UserService;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
 import konkuk.chacall.domain.user.presentation.dto.response.UserResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
+import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
@@ -23,19 +25,20 @@ public class UserController {
     @Operation(summary = "[마이페이지] 회원 정보 조회", description = "사용자(고객)의 정보를 조회합니다. (사장님, 일반유저 무관)")
     @ExceptionDescription(SwaggerResponseDescription.GET_USER_INFO)
     @GetMapping("/me")
-    public BaseResponse<UserResponse> getUserInfo() {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-        return BaseResponse.ok(userService.getUserInfo(1L));
+    public BaseResponse<UserResponse> getUserInfo(
+            @Parameter(hidden = true) @UserId final Long userId
+    ) {
+        return BaseResponse.ok(userService.getUserInfo(userId));
     }
 
     @Operation(summary = "[마이페이지] 회원 정보 수정", description = "사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)")
     @ExceptionDescription(SwaggerResponseDescription.UPDATE_USER_INFO)
     @PatchMapping("/me")
     public BaseResponse<Void> updateUserInfo(
-            final @RequestBody @Valid UpdateUserInfoRequest request
+            @RequestBody @Valid final UpdateUserInfoRequest request,
+            @Parameter(hidden = true) @UserId final Long userId
     ) {
-        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
-         userService.updateUserInfo(1L, request);
+         userService.updateUserInfo(userId, request);
 
          return BaseResponse.ok(null);
     }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -1,0 +1,38 @@
+package konkuk.chacall.domain.user.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import konkuk.chacall.domain.user.application.UserService;
+import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import konkuk.chacall.domain.user.presentation.dto.response.GetUserInfoResponse;
+import konkuk.chacall.global.common.dto.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "User API", description = "전체 사용자(마이페이지) 관련 API")
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "[마이페이지] 회원 정보 조회", description = "사용자(고객)의 정보를 조회합니다. (사장님, 일반유저 무관)")
+    @GetMapping("/me")
+    public BaseResponse<GetUserInfoResponse> getUserInfo() {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+        return BaseResponse.ok(userService.getUserInfo(1L));
+    }
+
+    @Operation(summary = "[마이페이지] 회원 정보 수정", description = "사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)")
+    @PatchMapping("/me")
+    public BaseResponse<Void> updateUserInfo(UpdateUserInfoRequest request) {
+        // todo 추후에 토큰 추가될 시 id 값은 토큰에서 추출하여 전달
+         userService.updateUserInfo(1L, request);
+
+         return BaseResponse.ok(null);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
@@ -23,7 +23,6 @@ public record UpdateUserInfoRequest(
         String gender,
 
         @Schema(description = "약관 동의 여부", example = "true")
-        @NotBlank(message = "약관 동의 여부는 비어 있을 수 없습니다.")
         boolean termAgreed
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
@@ -1,0 +1,29 @@
+package konkuk.chacall.domain.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+@Schema(description = "사용자 정보 수정 요청 DTO")
+public record UpdateUserInfoRequest(
+
+        @Schema(description = "프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        @NotBlank(message = "프로필 이미지 URL은 비어 있을 수 없습니다.")
+        String profileImageUrl,
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        @NotBlank(message = "이름은 비어 있을 수 없습니다.")
+        String name,
+
+        @Schema(description = "사용자 이메일", example = "chacall@kokuk.ac.kr")
+        @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+        String email,
+
+        @Schema(description = "사용자 성별", example = "남성")
+        @NotBlank(message = "성별은 비어 있을 수 없습니다.")
+        String gender,
+
+        @Schema(description = "약관 동의 여부", example = "true")
+        @NotBlank(message = "약관 동의 여부는 비어 있을 수 없습니다.")
+        boolean termAgreed
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
@@ -2,6 +2,7 @@ package konkuk.chacall.domain.user.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 
 @Schema(description = "사용자 정보 수정 요청 DTO")
 public record UpdateUserInfoRequest(
@@ -23,6 +24,7 @@ public record UpdateUserInfoRequest(
         String gender,
 
         @Schema(description = "약관 동의 여부", example = "true")
-        boolean termAgreed
+        @NotNull(message = "약관 동의 여부는 비어 있을 수 없습니다.")
+        Boolean termAgreed
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/UpdateUserInfoRequest.java
@@ -1,6 +1,7 @@
 package konkuk.chacall.domain.user.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
@@ -17,6 +18,7 @@ public record UpdateUserInfoRequest(
 
         @Schema(description = "사용자 이메일", example = "chacall@kokuk.ac.kr")
         @NotBlank(message = "이메일은 비어 있을 수 없습니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
         String email,
 
         @Schema(description = "사용자 성별", example = "남성")

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/GetUserInfoResponse.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/GetUserInfoResponse.java
@@ -1,0 +1,21 @@
+package konkuk.chacall.domain.user.presentation.dto.response;
+
+import konkuk.chacall.domain.user.domain.model.User;
+
+public record GetUserInfoResponse(
+        String profileImageUrl,
+        String name,
+        String email,
+        String gender,
+        boolean termAgreed
+) {
+    public static GetUserInfoResponse from(User user) {
+        return new GetUserInfoResponse(
+                user.getProfileImageUrl(),
+                user.getName(),
+                user.getEmail(),
+                user.getGender() == null ? null : user.getGender().getValue(),
+                user.isTermsAgreed()
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/UserResponse.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/UserResponse.java
@@ -2,15 +2,15 @@ package konkuk.chacall.domain.user.presentation.dto.response;
 
 import konkuk.chacall.domain.user.domain.model.User;
 
-public record GetUserInfoResponse(
+public record UserResponse(
         String profileImageUrl,
         String name,
         String email,
         String gender,
         boolean termAgreed
 ) {
-    public static GetUserInfoResponse from(User user) {
-        return new GetUserInfoResponse(
+    public static UserResponse from(User user) {
+        return new UserResponse(
                 user.getProfileImageUrl(),
                 user.getName(),
                 user.getEmail(),

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode implements ResponseCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, 60001, "사용자를 찾을 수 없습니다."),
     USER_ALREADY_EXISTS(HttpStatus.CONFLICT, 60002, "이미 존재하는 사용자입니다."),
     USER_NICKNAME_DUPLICATION(HttpStatus.CONFLICT, 60003, "이미 존재하는 닉네임입니다."),
+    USER_GENDER_MISMATCH(HttpStatus.BAD_REQUEST, 60004, "일치하는 성별이 없습니다."),
 
     /**
      * BankAccount

--- a/src/main/java/konkuk/chacall/global/common/security/oauth2/auth/AuthController.java
+++ b/src/main/java/konkuk/chacall/global/common/security/oauth2/auth/AuthController.java
@@ -35,7 +35,7 @@ public class AuthController {
      */
     @Operation(summary = "JWT Access Token 발급", description = "loginTokenKey를 통해 JWT Access Token을 발급받습니다." +
             " 카카오 소셜 로그인 직후 리다이렉트 url의 쿼리 파라미터에서 loginTokenKey를 꺼내서 요청해주세요.")
-    @ExceptionDescription(SwaggerResponseDescription.LOGOUT)
+    @ExceptionDescription(SwaggerResponseDescription.ISSUE_TOKEN)
     @PostMapping("/token")
     public BaseResponse<AuthTokenResponse> getToken(
             @RequestBody @Valid AuthTokenRequest request

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -22,6 +22,14 @@ public enum SwaggerResponseDescription {
             AUTH_INVALID_LOGIN_TOKEN_KEY
     ))),
 
+    // User
+    GET_USER_INFO(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    UPDATE_USER_INFO(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+
     // Owner
     OWNER_REGISTER_BANK_ACCOUNT(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -19,8 +19,7 @@ public enum SwaggerResponseDescription {
 
     ))),
     ISSUE_TOKEN(new LinkedHashSet<>(Set.of(
-            AUTH_INVALID_LOGIN_TOKEN_KEY,
-            USER_NOT_FOUND
+            AUTH_INVALID_LOGIN_TOKEN_KEY
     ))),
 
     // Owner


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #11 

## 📝작업 내용

마이페이지 정보에서 약관 동의 항목이 존재해서 사용자 테이블에 약관 동의 여부를 판단하는 컬럼을 추가했습니다!
그것말고는 딱히 특이사항은 없습니다~

### 스크린샷
<img width="1036" height="670" alt="스크린샷 2025-09-15 오후 5 07 12" src="https://github.com/user-attachments/assets/2501d54f-e9bb-4a60-a159-a1384f78dace" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 마이페이지 API 추가: 내 정보 조회(GET /users/me) 및 수정(PUT /users/me)
  - 사용자 서비스 및 요청/응답 DTO 추가: UserService, UpdateUserInfoRequest, UserResponse
  - 프로필 이미지·이름·이메일·성별·약관 동의(termAgreed) 수정 및 저장 지원
  - 성별 변환 로직(Gender.from) 추가

- **오류 처리**
  - 유효하지 않은 성별 입력에 대해 USER_GENDER_MISMATCH 오류 반환
  - 존재하지 않는 사용자 접근 시 USER_NOT_FOUND 처리

- **문서**
  - Swagger에 사용자 조회/수정 문서화 및 관련 응답 설명 추가
  - 토큰 발급 응답 설명 수정
<!-- end of auto-generated comment: release notes by coderabbit.ai -->