### PR TITLE
[FEAT] 사장님 - 예약내역 목록 및 상세 조회 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -2,14 +2,14 @@ package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.bankAccount.BankAccountService;
 import konkuk.chacall.domain.owner.application.chatTemplate.ChatTemplateService;
+import konkuk.chacall.domain.owner.application.reservation.OwnerReservationService;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
-import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.UpdateChatTemplateRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.*;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +21,7 @@ public class OwnerService {
 
     private final BankAccountService bankAccountService;
     private final ChatTemplateService chatTemplateService;
+    private final OwnerReservationService ownerReservationService;
 
     // 파사드에서 사장님 검증을 거침으로써 서비스 로직에서는 사장님 검증에 신경쓰지 않도록 책임 분리
     private final OwnerValidator ownerValidator;
@@ -88,5 +89,13 @@ public class OwnerService {
 
         // 자주 쓰는 채팅 삭제 로직 호출
         chatTemplateService.deleteChatTemplate(chatTemplateId);
+    }
+
+    public CursorPagingResponse<OwnerReservationHistoryResponse> getOwnerReservations(GetReservationHistoryRequest request, Long ownerId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 사장님 예약 내역 조회 로직 호출
+        return ownerReservationService.getOwnerReservations(ownerId, request.status(), request.getCursorOrDefault(), request.getPageSizeOrDefault());
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -108,6 +108,6 @@ public class OwnerService {
         ownerValidator.validateAndGetOwner(ownerId);
 
         // 사장님 예약 내역 상세 조회 로직 호출
-        return ownerReservationService.getReservationDetail(reservationId);
+        return ownerReservationService.getReservationDetail(ownerId, reservationId);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -7,6 +7,7 @@ import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.owner.presentation.dto.request.*;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationDetailResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
@@ -97,5 +98,13 @@ public class OwnerService {
 
         // 사장님 예약 내역 조회 로직 호출
         return ownerReservationService.getOwnerReservations(ownerId, request.status(), request.getCursorOrDefault(), request.getPageSizeOrDefault());
+    }
+
+    public OwnerReservationDetailResponse getReservationDetail(Long ownerId, Long reservationId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 사장님 예약 내역 상세 조회 로직 호출
+        return ownerReservationService.getReservationDetail(reservationId);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -97,7 +97,7 @@ public class OwnerService {
         ownerValidator.validateAndGetOwner(ownerId);
 
         // 사장님 예약 내역 조회 로직 호출
-        return ownerReservationService.getOwnerReservations(ownerId, request.status(), request.getCursorOrDefault(), request.getPageSizeOrDefault());
+        return ownerReservationService.getOwnerReservations(ownerId, request.status(), request.pagingRequest().getCursorOrDefault(), request.pagingRequest().getSizeOrDefault());
     }
 
     public OwnerReservationDetailResponse getReservationDetail(Long ownerId, Long reservationId) {

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -11,7 +11,9 @@ import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationDet
 import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
+import konkuk.chacall.global.common.dto.PagingRequest;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -97,7 +99,8 @@ public class OwnerService {
         ownerValidator.validateAndGetOwner(ownerId);
 
         // 사장님 예약 내역 조회 로직 호출
-        return ownerReservationService.getOwnerReservations(ownerId, request.status(), request.pagingRequest().getCursorOrDefault(), request.pagingRequest().getSizeOrDefault());
+        PagingRequest pagingRequest = request.pagingOrDefault();
+        return ownerReservationService.getOwnerReservations(ownerId, request.status(), pagingRequest.cursor(), pagingRequest.size());
     }
 
     public OwnerReservationDetailResponse getReservationDetail(Long ownerId, Long reservationId) {

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -40,16 +40,15 @@ public class OwnerReservationService {
 
         Long nextCursor = responses.isEmpty() ? null : responses.get(responses.size() - 1).reservationId();
 
-        return CursorPagingResponse.of(responses, pageSize, nextCursor, ownerReservationSlice.hasNext());
+        return CursorPagingResponse.of(responses, nextCursor, ownerReservationSlice.hasNext());
     }
 
     /**
      * 예약 목록 조회
      */
     private Slice<Reservation> findReservations(Long ownerId, ReservationStatus status, Long lastCursor, int pageSize) {
-        Long currentCursor = (lastCursor == null) ? Long.MAX_VALUE : lastCursor;
         return reservationRepository
-                .findOwnerReservationsByStatusWithCursor(ownerId, status, currentCursor, PageRequest.of(0, pageSize));
+                .findOwnerReservationsByStatusWithCursor(ownerId, status, lastCursor, PageRequest.of(0, pageSize));
     }
 
     /**

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -1,0 +1,78 @@
+package konkuk.chacall.domain.owner.application.reservation;
+
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+import konkuk.chacall.domain.user.domain.model.Role;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.domain.user.domain.repository.UserRepository;
+import konkuk.chacall.global.common.domain.BaseStatus;
+import konkuk.chacall.global.common.dto.CursorPagingResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class OwnerReservationService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+
+    public CursorPagingResponse<OwnerReservationHistoryResponse> getOwnerReservations(Long ownerId, ReservationStatus status, Long lastCursor, int pageSize) {
+        // 예약 목록 조회
+        Slice<Reservation> ownerReservationSlice = findReservations(ownerId, status, lastCursor, pageSize);
+        List<Reservation> ownerReservationList = ownerReservationSlice.getContent();
+
+        // 손님 ID 리스트로 User 정보 한 번에 조회
+        Map<Long, User> customerMap = getCustomerMap(ownerReservationList);
+
+        // 미리 조회한 User 정보를 사용해 DTO 로 변환
+        List<OwnerReservationHistoryResponse> responses = mapToReservationHistory(ownerReservationList, customerMap);
+
+        Long nextCursor = responses.isEmpty() ? null : responses.get(responses.size() - 1).reservationId();
+
+        return CursorPagingResponse.of(responses, pageSize, nextCursor, ownerReservationSlice.hasNext());
+    }
+
+    /**
+     * 예약 목록 조회
+     */
+    private Slice<Reservation> findReservations(Long ownerId, ReservationStatus status, Long lastCursor, int pageSize) {
+        Long currentCursor = (lastCursor == null) ? Long.MAX_VALUE : lastCursor;
+        return reservationRepository
+                .findOwnerReservationsByStatusWithCursor(ownerId, status, currentCursor, PageRequest.of(0, pageSize));
+    }
+
+    /**
+     * 예약 목록에 포함된 손님 정보 Map 조회
+     */
+    private Map<Long, User> getCustomerMap(List<Reservation> reservations) {
+        List<Long> customerIds = reservations.stream()
+                .map(reservation -> reservation.getMember().getUserId())
+                .toList();
+
+        return userRepository.findAllByUserIdInAndRoleAndStatus(customerIds, Role.MEMBER, BaseStatus.ACTIVE).stream()
+                .collect(Collectors.toMap(User::getUserId, user -> user));
+    }
+
+    /**
+     * 예약 목록과 손님 정보를 조합하여 DTO 리스트로 변환
+     */
+    private List<OwnerReservationHistoryResponse> mapToReservationHistory(List<Reservation> reservations, Map<Long, User> customerMap) {
+        return reservations.stream()
+                .map(reservation -> {
+                    User customer = customerMap.get(reservation.getMember().getUserId());
+                    return OwnerReservationHistoryResponse.of(reservation, customer);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -42,9 +42,7 @@ public class OwnerReservationService {
         // 미리 조회한 User 정보를 사용해 DTO 로 변환
         List<OwnerReservationHistoryResponse> responses = mapToReservationHistory(ownerReservationList, customerMap);
 
-        Long nextCursor = responses.isEmpty() ? null : responses.get(responses.size() - 1).reservationId();
-
-        return CursorPagingResponse.of(responses, nextCursor, ownerReservationSlice.hasNext());
+        return CursorPagingResponse.of(responses, OwnerReservationHistoryResponse::reservationId, ownerReservationSlice.hasNext());
     }
 
     public OwnerReservationDetailResponse getReservationDetail(Long ownerId, Long reservationId) {

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -10,6 +10,7 @@ import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
 import konkuk.chacall.global.common.domain.BaseStatus;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
+import konkuk.chacall.global.common.exception.BusinessException;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -46,10 +47,14 @@ public class OwnerReservationService {
         return CursorPagingResponse.of(responses, nextCursor, ownerReservationSlice.hasNext());
     }
 
-    public OwnerReservationDetailResponse getReservationDetail(Long reservationId) {
+    public OwnerReservationDetailResponse getReservationDetail(Long ownerId, Long reservationId) {
         // ID로 예약 정보와 연관된 모든 데이터 한 번에 조회
         Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        if(!reservation.isOwnedBy(ownerId)) {
+            throw new BusinessException(ErrorCode.RESERVATION_NOT_OWNED);
+        }
 
         // DTO 로 변환하여 반환
         return OwnerReservationDetailResponse.of(reservation, reservation.getMember());

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -1,5 +1,6 @@
 package konkuk.chacall.domain.owner.application.reservation;
 
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationDetailResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
@@ -9,6 +10,8 @@ import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
 import konkuk.chacall.global.common.domain.BaseStatus;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
@@ -41,6 +44,15 @@ public class OwnerReservationService {
         Long nextCursor = responses.isEmpty() ? null : responses.get(responses.size() - 1).reservationId();
 
         return CursorPagingResponse.of(responses, nextCursor, ownerReservationSlice.hasNext());
+    }
+
+    public OwnerReservationDetailResponse getReservationDetail(Long reservationId) {
+        // ID로 예약 정보와 연관된 모든 데이터 한 번에 조회
+        Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        // DTO 로 변환하여 반환
+        return OwnerReservationDetailResponse.of(reservation, reservation.getMember());
     }
 
     /**

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
 import konkuk.chacall.domain.owner.presentation.dto.request.*;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationDetailResponse;
 import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
@@ -142,7 +143,9 @@ public class OwnerController {
         return BaseResponse.ok(null);
     }
 
-    @Operation(summary = "사장님 예약 내역 목록 조회 (무한 스크롤)")
+    @Operation(
+            summary = "사장님 예약 내역 목록 조회 (무한 스크롤)",
+            description = "사장님의 예약 내역 목록을 조회합니다.")
     @GetMapping("/me/reservations")
     public BaseResponse<CursorPagingResponse<OwnerReservationHistoryResponse>> getOwnerReservations(
             @Valid @ParameterObject final GetReservationHistoryRequest request,
@@ -151,5 +154,18 @@ public class OwnerController {
         return BaseResponse.ok(ownerService.getOwnerReservations(
                 request,
                 ownerId));
+    }
+
+    @Operation(
+            summary = "예약 상세 조회",
+            description = "예약 ID로 예약 상세 정보를 조회합니다.")
+    @GetMapping("me/reservations/{reservationId}")
+    public BaseResponse<OwnerReservationDetailResponse> getReservationDetail(
+            @PathVariable final Long reservationId,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(ownerService.getReservationDetail(
+                ownerId,
+                reservationId));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -5,19 +5,20 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.owner.application.OwnerService;
-import konkuk.chacall.domain.owner.presentation.dto.request.RegisterBankAccountRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.RegisterChatTemplateRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.UpdateBankAccountRequest;
-import konkuk.chacall.domain.owner.presentation.dto.request.UpdateChatTemplateRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.*;
 import konkuk.chacall.domain.owner.presentation.dto.response.BankAccountResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.OwnerReservationHistoryResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.domain.owner.presentation.dto.response.ChatTemplateResponse;
 import konkuk.chacall.global.common.dto.BaseResponse;
+import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
+
 import java.util.List;
 
 @Tag(name = "Owner API", description = "사장님 관련 API")
@@ -66,7 +67,7 @@ public class OwnerController {
             @PathVariable final Long bankAccountId,
             @RequestBody @Valid final UpdateBankAccountRequest request,
             @Parameter(hidden = true) @UserId final Long ownerId
-            ) {
+    ) {
         ownerService.updateBankAccount(ownerId, bankAccountId, request);
         return BaseResponse.ok(null);
     }
@@ -139,5 +140,16 @@ public class OwnerController {
             @Parameter(hidden = true) @UserId final Long ownerId) {
         ownerService.deleteChatTemplate(ownerId, chatTemplateId);
         return BaseResponse.ok(null);
+    }
+
+    @Operation(summary = "사장님 예약 내역 목록 조회 (무한 스크롤)")
+    @GetMapping("/me/reservations")
+    public BaseResponse<CursorPagingResponse<OwnerReservationHistoryResponse>> getOwnerReservations(
+            @Valid @ParameterObject final GetReservationHistoryRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(ownerService.getOwnerReservations(
+                request,
+                ownerId));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -146,6 +146,7 @@ public class OwnerController {
     @Operation(
             summary = "사장님 예약 내역 목록 조회 (무한 스크롤)",
             description = "사장님의 예약 내역 목록을 조회합니다.")
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_GET_RESERVATION_HISTORY)
     @GetMapping("/me/reservations")
     public BaseResponse<CursorPagingResponse<OwnerReservationHistoryResponse>> getOwnerReservations(
             @Valid @ParameterObject final GetReservationHistoryRequest request,
@@ -157,8 +158,9 @@ public class OwnerController {
     }
 
     @Operation(
-            summary = "예약 상세 조회",
+            summary = "사장님 예약 상세 조회",
             description = "예약 ID로 예약 상세 정보를 조회합니다.")
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_GET_RESERVATION_DETAIL)
     @GetMapping("me/reservations/{reservationId}")
     public BaseResponse<OwnerReservationDetailResponse> getReservationDetail(
             @PathVariable final Long reservationId,

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -63,7 +63,7 @@ public class OwnerController {
             description = "사장님이 자신의 은행 계좌를 수정합니다."
     )
     @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_BANK_ACCOUNT)
-    @PatchMapping("/me/bank-accounts/{bankAccountId}")
+    @PutMapping("/me/bank-accounts/{bankAccountId}")
     public BaseResponse<Void> updateBankAccount(
             @PathVariable final Long bankAccountId,
             @RequestBody @Valid final UpdateBankAccountRequest request,
@@ -120,7 +120,7 @@ public class OwnerController {
             description = "사장님이 자주 쓰는 채팅을 수정합니다."
     )
     @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_CHAT_TEMPLATE)
-    @PatchMapping("/me/chat-templates/{chatTemplateId}")
+    @PutMapping("/me/chat-templates/{chatTemplateId}")
     public BaseResponse<Void> updateChatTemplate(
             @PathVariable final Long chatTemplateId,
             @RequestBody @Valid final UpdateChatTemplateRequest request,

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
@@ -2,16 +2,15 @@ package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotNull;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 
 public record GetReservationHistoryRequest(
         @Schema(description = "조회할 예약 상태",
                 requiredMode = Schema.RequiredMode.REQUIRED,
-                example = "PENDING")
-        @NotBlank(message = "예약 상태는 필수입니다.")
-        @Pattern(regexp = "^(PENDING|CONFIRMED|CANCELLED)$", message = "유효하지 않은 예약 상태입니다.")
+                example = "PENDING",
+                allowableValues = {"PENDING", "CONFIRMED", "CANCELLED"})
+        @NotNull(message = "예약 상태는 필수입니다.")
         ReservationStatus status,
 
         @Schema(description = "마지막으로 조회된 예약의 ID (다음 페이지 요청 시 사용)",

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+import konkuk.chacall.global.common.dto.HasPaging;
 import konkuk.chacall.global.common.dto.PagingRequest;
 
 public record GetReservationHistoryRequest(
@@ -16,5 +17,5 @@ public record GetReservationHistoryRequest(
 
         @Valid
         PagingRequest pagingRequest
-) {
+) implements HasPaging {
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
@@ -1,9 +1,10 @@
 package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+import konkuk.chacall.global.common.dto.PagingRequest;
 
 public record GetReservationHistoryRequest(
         @Schema(description = "조회할 예약 상태",
@@ -13,34 +14,7 @@ public record GetReservationHistoryRequest(
         @NotNull(message = "예약 상태는 필수입니다.")
         ReservationStatus status,
 
-        @Schema(description = "마지막으로 조회된 예약의 ID (다음 페이지 요청 시 사용)",
-                example = "120",
-                nullable = true)
-        Long cursor,
-
-        @Schema(description = "한 페이지에 조회할 개수",
-                example = "30",
-                defaultValue = "20",
-                minimum = "1",
-                nullable = true)
-        @Min(value = 1, message = "size 는 1 이상이어야 합니다.")
-        Integer size
+        @Valid
+        PagingRequest pagingRequest
 ) {
-    /**
-     * size 가 null 이면 기본값 20을, 아니면 그 값을 반환
-     *
-     * @return int 타입의 페이지 크기
-     */
-    public int getPageSizeOrDefault() {
-        return (this.size == null) ? 20 : this.size;
-    }
-
-    /**
-     * cursor 가 null 이면 기본값 : Long 의 최대값을, 아니면 그 값을 반환
-     *
-     * @return Long 타입의 커서값
-     */
-    public Long getCursorOrDefault() {
-        return (this.cursor == null) ? Long.MAX_VALUE : this.cursor;
-    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/GetReservationHistoryRequest.java
@@ -1,0 +1,47 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+
+public record GetReservationHistoryRequest(
+        @Schema(description = "조회할 예약 상태",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "PENDING")
+        @NotBlank(message = "예약 상태는 필수입니다.")
+        @Pattern(regexp = "^(PENDING|CONFIRMED|CANCELLED)$", message = "유효하지 않은 예약 상태입니다.")
+        ReservationStatus status,
+
+        @Schema(description = "마지막으로 조회된 예약의 ID (다음 페이지 요청 시 사용)",
+                example = "120",
+                nullable = true)
+        Long cursor,
+
+        @Schema(description = "한 페이지에 조회할 개수",
+                example = "30",
+                defaultValue = "20",
+                minimum = "1",
+                nullable = true)
+        @Min(value = 1, message = "size 는 1 이상이어야 합니다.")
+        Integer size
+) {
+    /**
+     * size 가 null 이면 기본값 20을, 아니면 그 값을 반환
+     *
+     * @return int 타입의 페이지 크기
+     */
+    public int getPageSizeOrDefault() {
+        return (this.size == null) ? 20 : this.size;
+    }
+
+    /**
+     * cursor 가 null 이면 기본값 : Long 의 최대값을, 아니면 그 값을 반환
+     *
+     * @return Long 타입의 커서값
+     */
+    public Long getCursorOrDefault() {
+        return (this.cursor == null) ? Long.MAX_VALUE : this.cursor;
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
@@ -1,0 +1,37 @@
+package konkuk.chacall.domain.owner.presentation.dto.response;
+
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.user.domain.model.User;
+
+import java.util.List;
+
+public record OwnerReservationDetailResponse(
+        String userProfileImage,
+        String username,
+        String address,
+        List<String> dateTimeInfos,
+        String pdfUrl,
+        String menu,
+        Integer deposit,
+        String electricityInfo,
+        String etcRequest
+) {
+    public static OwnerReservationDetailResponse of(Reservation reservation, User member) {
+        List<String> dateTimeList = reservation.getReservationInfo().getFormattedDateTimeInfos();
+
+        // boolean 값을 화면에 표시할 문자열로 변환
+        String electricity = reservation.getReservationInfo().isUseElectricity() ? "가능" : "불가능";
+
+        return new OwnerReservationDetailResponse(
+                member.getProfileImageUrl(),
+                member.getName(),
+                reservation.getReservationInfo().getReservationAddress(),
+                dateTimeList,
+                reservation.getPdfUrl(),
+                reservation.getReservationInfo().getMenu(),
+                reservation.getReservationInfo().getReservationDeposit(),
+                electricity,
+                reservation.getReservationInfo().getEtcRequest()
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
@@ -1,19 +1,40 @@
 package konkuk.chacall.domain.owner.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.user.domain.model.User;
 
 import java.util.List;
 
 public record OwnerReservationDetailResponse(
+        @Schema(description = "상대방(손님)의 프로필 이미지 URL",
+                example = "https://image.url/path/profile.jpg")
         String userProfileImage,
+        @Schema(description = "상대방의 이름 또는 닉네임",
+                example = "김차콜")
         String username,
+        @Schema(description = "예약 주소",
+                example = "서울 광진구 화양동 123-45")
         String address,
+        @Schema(description = "예약 날짜 및 운영 시간 정보 리스트 (최대 2개)",
+                example = "[\"2025-09-20 13시~19시\", \"2025-09-21 13시~19시\"]")
         List<String> dateTimeInfos,
+        @Schema(description = "견적서 PDF 다운로드 URL (null 일 수 있음)",
+                nullable = true,
+                example = "https://storage.url/quotes/reservation_123.pdf")
         String pdfUrl,
+        @Schema(description = "운영 메뉴",
+                example = "핫도그, 국밥, 짜장면")
         String menu,
-        Integer deposit,
+        @Schema(description = "지불된 예약금액",
+                example = "50000원")
+        String deposit,
+        @Schema(description = "전기 사용 가능 여부",
+                example = "가능")
         String electricityInfo,
+        @Schema(description = "기타 요청 사항 (null 일 수 있음)",
+                nullable = true,
+                example = "음식을 많이 주세요, 늦지말아주세요")
         String etcRequest
 ) {
     public static OwnerReservationDetailResponse of(Reservation reservation, User member) {
@@ -29,7 +50,7 @@ public record OwnerReservationDetailResponse(
                 dateTimeList,
                 reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),
-                reservation.getReservationInfo().getReservationDeposit(),
+                reservation.getReservationInfo().getReservationDeposit() + "원",
                 electricity,
                 reservation.getReservationInfo().getEtcRequest()
         );

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
@@ -13,18 +13,13 @@ public record OwnerReservationHistoryResponse(
         List<String> dateTimeInfo
 ) {
 
-    public static OwnerReservationHistoryResponse of(Reservation reservation) {
-        User customer = reservation.getMember();
-
-        // Embedded 객체 내부의 필드에 접근
-        List<String> dateTimeList = reservation.getReservationInfo().getReservationDate().getDates().stream()
-                .map(date -> date.toString() + " " + reservation.getReservationInfo().getOperationHour())
-                .toList();
+    public static OwnerReservationHistoryResponse of(Reservation reservation, User member) {
+        List<String> dateTimeList = reservation.getReservationInfo().getFormattedDateTimeInfos();
 
         return new OwnerReservationHistoryResponse(
                 reservation.getReservationId(),
-                customer.getProfileImageUrl(),
-                customer.getName(),
+                member.getProfileImageUrl(),
+                member.getName(),
                 reservation.getReservationInfo().getReservationAddress(),
                 dateTimeList
         );

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
@@ -1,0 +1,32 @@
+package konkuk.chacall.domain.owner.presentation.dto.response;
+
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.user.domain.model.User;
+
+import java.util.List;
+
+public record OwnerReservationHistoryResponse(
+        Long reservationId,
+        String userProfileImage,
+        String username,
+        String address,
+        List<String> dateTimeInfo
+) {
+
+    public static OwnerReservationHistoryResponse of(Reservation reservation) {
+        User customer = reservation.getMember();
+
+        // Embedded 객체 내부의 필드에 접근
+        List<String> dateTimeList = reservation.getReservationInfo().getReservationDate().getDates().stream()
+                .map(date -> date.toString() + " " + reservation.getReservationInfo().getOperationHour())
+                .toList();
+
+        return new OwnerReservationHistoryResponse(
+                reservation.getReservationId(),
+                customer.getProfileImageUrl(),
+                customer.getName(),
+                reservation.getReservationInfo().getReservationAddress(),
+                dateTimeList
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
@@ -1,16 +1,23 @@
 package konkuk.chacall.domain.owner.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.user.domain.model.User;
 
 import java.util.List;
 
 public record OwnerReservationHistoryResponse(
+        @Schema(description = "예약 내역 식별자", example = "1")
         Long reservationId,
+        @Schema(description = "유저(고객) 프로필 이미지", example = "http://image.png")
         String userProfileImage,
+        @Schema(description = "유저(고객) 이름", example = "홍길동")
         String username,
+        @Schema(description = "예약 주소", example = "서울 광진구 화양동")
         String address,
-        List<String> dateTimeInfo
+        @Schema(description = "예약 날짜 및 운영 시간 정보 리스트 (최대 2개)",
+                example = "[\"2025-09-20 13시~19시\", \"2025-09-21 13시~19시\"]")
+        List<String> dateTimeInfos
 ) {
 
     public static OwnerReservationHistoryResponse of(Reservation reservation, User member) {

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -6,6 +6,8 @@ import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.DomainRuleException;
 import lombok.*;
 
 @Getter
@@ -39,4 +41,8 @@ public class Reservation extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "food_truck_id", nullable = false)
     private FoodTruck foodTruck;
+
+    public boolean isOwnedBy(Long ownerId) {
+        return foodTruck.getOwner().getUserId().equals(ownerId);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.reservation.domain;
+package konkuk.chacall.domain.reservation.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -1,15 +1,19 @@
 package konkuk.chacall.domain.reservation.domain.model;
 
 import jakarta.persistence.*;
+import konkuk.chacall.domain.foodtruck.domain.FoodTruck;
 import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Getter
 @Entity
 @Table(name = "reservations")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Reservation extends BaseEntity {
 
     @Id
@@ -25,4 +29,14 @@ public class Reservation extends BaseEntity {
 
     @Embedded
     private ReservationInfo reservationInfo; // 예약 정보
+
+    // '예약자(손님)'와의 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User member;
+
+    // '예약된 푸드트럭'과의 연관관계 (N:1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_truck_id", nullable = false)
+    private FoodTruck foodTruck;
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
@@ -8,6 +8,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Optional;
+
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     @Query("SELECT r FROM Reservation r " +
@@ -20,4 +22,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
             @Param("status") ReservationStatus status,
             @Param("lastCursor") Long lastCursor,
             Pageable pageable);
+
+
+    @Query("SELECT r FROM Reservation r " +
+            "JOIN FETCH r.member m " +
+            "JOIN FETCH r.foodTruck ft " +
+            "JOIN FETCH ft.owner o " +
+            "WHERE r.reservationId = :reservationId")
+    Optional<Reservation> findByIdWithDetails(@Param("reservationId") Long reservationId);
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
@@ -1,0 +1,7 @@
+package konkuk.chacall.domain.reservation.domain.repository;
+
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
@@ -1,7 +1,19 @@
 package konkuk.chacall.domain.reservation.domain.repository;
 
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+    @Query("SELECT r FROM Reservation r " +
+            "JOIN FETCH r.member m " +                  // 예약자 정보 함께 조회
+            "JOIN FETCH r.foodTruck ft " +              // 푸드트럭 정보 함께 조회
+            "JOIN FETCH ft.owner o " +                  // 푸드트럭의 사장님 정보 함께 조회
+            "WHERE o.userId = :ownerId AND r.reservationStatus = :status ")
+    List<Reservation> findOwnerReservationsByStatus(@Param("ownerId") Long ownerId, @Param("status") ReservationStatus status);
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/repository/ReservationRepository.java
@@ -2,18 +2,22 @@ package konkuk.chacall.domain.reservation.domain.repository;
 
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.List;
-
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     @Query("SELECT r FROM Reservation r " +
-            "JOIN FETCH r.member m " +                  // 예약자 정보 함께 조회
-            "JOIN FETCH r.foodTruck ft " +              // 푸드트럭 정보 함께 조회
-            "JOIN FETCH ft.owner o " +                  // 푸드트럭의 사장님 정보 함께 조회
-            "WHERE o.userId = :ownerId AND r.reservationStatus = :status ")
-    List<Reservation> findOwnerReservationsByStatus(@Param("ownerId") Long ownerId, @Param("status") ReservationStatus status);
+            "WHERE r.foodTruck.owner.userId = :ownerId " +
+            "AND r.reservationStatus = :status " +
+            "AND r.reservationId < :lastCursor " +
+            "ORDER BY r.reservationId DESC")
+    Slice<Reservation> findOwnerReservationsByStatusWithCursor(
+            @Param("ownerId") Long ownerId,
+            @Param("status") ReservationStatus status,
+            @Param("lastCursor") Long lastCursor,
+            Pageable pageable);
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/DateRange.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/DateRange.java
@@ -1,0 +1,26 @@
+package konkuk.chacall.domain.reservation.domain.value;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+
+import java.time.LocalDate;
+
+@Embeddable
+public record DateRange(
+        @Column(name = "start_date", nullable = false)
+        LocalDate startDate,
+
+        @Column(name = "end_date", nullable = false)
+        LocalDate endDate
+) {
+    /**
+     * 객체 생성 시 유효성 검증 (종료일이 시작일보다 빠를 수 없음)
+     */
+    public DateRange {
+        if (endDate.isBefore(startDate)) {
+            throw new DomainRuleException(ErrorCode.INVALID_DATE_RANGE);
+        }
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationDateList.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationDateList.java
@@ -1,10 +1,16 @@
 package konkuk.chacall.domain.reservation.domain.value;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
@@ -12,25 +18,62 @@ import java.util.List;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReservationDateList {
 
-    private final List<LocalDate> dates;
+    private static final DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
-    public static ReservationDateList of(List<LocalDate> dates) {
-        return new ReservationDateList(dates == null ? List.of() : List.copyOf(dates));
-    }
+    private final List<DateRange> ranges;
 
-    public List<LocalDate> getDates() {
-        return Collections.unmodifiableList(dates);
-    }
-
-    public boolean contains(LocalDate date) {
-        return dates != null && dates.contains(date);
-    }
-
-    public int size() {
-        return dates.size();
+    public static ReservationDateList of(List<DateRange> ranges) {
+        return new ReservationDateList(ranges == null ? List.of() : List.copyOf(ranges));
     }
 
     public boolean isEmpty() {
-        return size() == 0;
+        return ranges == null || ranges.isEmpty();
+    }
+
+    @JsonCreator(mode = JsonCreator.Mode.DELEGATING)
+    public static ReservationDateList fromJson(List<String> rawRanges) {
+        if (rawRanges == null || rawRanges.isEmpty()) return ReservationDateList.of(List.of());
+
+        List<DateRange> list = new ArrayList<>();
+
+        for (String range : rawRanges) {
+            if (range == null || range.isBlank()) continue;
+            String[] dates = range.split("~");
+
+            if (dates.length != 2) {
+                throw new DomainRuleException(ErrorCode.INVALID_DATE_INPUT);
+            }
+
+            LocalDate start = parseDot(dates[0].trim());
+            LocalDate end   = parseDot(dates[1].trim());
+            list.add(new DateRange(start, end));
+        }
+        return ReservationDateList.of(list);
+    }
+
+    public String toStorageString() {
+        if (isEmpty()) return "";
+
+        StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < ranges.size(); i++) {
+            DateRange range = ranges.get(i);
+
+            sb.append(range.startDate().format(DOT))
+                    .append("~")
+                    .append(range.endDate().format(DOT));
+
+            if (i < ranges.size() - 1) sb.append(",");
+        }
+
+        return sb.toString();
+    }
+
+    private static LocalDate parseDot(String s) {
+        try {
+            return LocalDate.parse(s, DOT);
+        } catch (DateTimeParseException e) {
+            throw new DomainRuleException(ErrorCode.INVALID_DATE_INPUT);
+        }
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -21,7 +21,7 @@ public class ReservationInfo {
 
     @Convert(converter = ReservationDateListConverter.class)
     @Column(nullable = false)
-    private List<LocalDate> reservationDate; // 예약 일정
+    private ReservationDateList reservationDate; // 예약 일정
 
     @Column(nullable = false, length = 50)
     private String operationHour; // 운영 시간대

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -37,4 +37,10 @@ public class ReservationInfo {
 
     @Column(length = 1000)
     private String etcRequest; // 기타 요청 사항
+
+    public List<String> getFormattedDateTimeInfos() {
+        return this.reservationDate.getDates().stream()
+                .map(date -> date.toString() + " " + this.operationHour)
+                .toList();
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 import org.apache.catalina.LifecycleState;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter
@@ -39,8 +40,11 @@ public class ReservationInfo {
     private String etcRequest; // 기타 요청 사항
 
     public List<String> getFormattedDateTimeInfos() {
-        return this.reservationDate.getDates().stream()
-                .map(date -> date.toString() + " " + this.operationHour)
+        DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        return this.reservationDate.getRanges().stream()
+                .map(date -> date.startDate().format(DOT) + " ~ " + date.endDate().format(DOT)
+                        + " " + this.operationHour)
                 .toList();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/konkuk/chacall/domain/user/domain/repository/UserRepository.java
@@ -6,6 +6,7 @@ import konkuk.chacall.global.common.domain.BaseStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUserIdAndRoleAndStatus(Long userId, Role role, BaseStatus status);
 
     boolean existsByUserIdAndRoleAndStatus(Long userId, Role role, BaseStatus status);
+
+    List<User> findAllByUserIdInAndRoleAndStatus(List<Long> userIds, Role role, BaseStatus status);
 }

--- a/src/main/java/konkuk/chacall/global/common/converter/ReservationDateListConverter.java
+++ b/src/main/java/konkuk/chacall/global/common/converter/ReservationDateListConverter.java
@@ -2,9 +2,14 @@ package konkuk.chacall.global.common.converter;
 
 import jakarta.persistence.AttributeConverter;
 import jakarta.persistence.Converter;
+import konkuk.chacall.domain.reservation.domain.value.DateRange;
 import konkuk.chacall.domain.reservation.domain.value.ReservationDateList;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,28 +20,35 @@ import java.util.stream.Collectors;
 @Converter(autoApply = false)
 public class ReservationDateListConverter implements AttributeConverter<ReservationDateList, String> {
 
-    private static final String DELIMITER = ",";
+    private static final String ITEM_DELIM = ",";  // 범위 간 구분자
+    private static final String RANGE_DELIM = "~"; // 시작/끝 구분자
+    private static final DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
     @Override
     public String convertToDatabaseColumn(ReservationDateList attribute) {
-        if (attribute == null || attribute.isEmpty()) {
-            return "";
-        }
-        return attribute.getDates().stream()
-                .map(LocalDate::toString) // ISO-8601 (yyyy-MM-dd)
-                .collect(Collectors.joining(DELIMITER));
+        if (attribute == null || attribute.isEmpty()) return "";
+        return attribute.toStorageString(); // "yyyy-MM-dd~yyyy-MM-dd,yyyy-MM-dd~yyyy-MM-dd"
     }
 
     @Override
     public ReservationDateList convertToEntityAttribute(String dbData) {
-        if (dbData == null || dbData.isBlank()) {
-            return ReservationDateList.of(List.of());
+        if (dbData == null || dbData.isBlank()) return ReservationDateList.of(List.of());
+
+        String[] parts = dbData.split(ITEM_DELIM);
+        List<DateRange> list = new ArrayList<>();
+
+        for (String part : parts) {
+            String trimmedPart = part.trim();
+            if (trimmedPart.isEmpty()) continue;
+
+            String[] dates = trimmedPart.split(RANGE_DELIM);
+            if (dates.length != 2) {
+                throw new DomainRuleException(ErrorCode.INVALID_DATE_INPUT);
+            }
+            LocalDate start = LocalDate.parse(dates[0].trim(), DOT); // ISO yyyy-MM-dd
+            LocalDate end   = LocalDate.parse(dates[1].trim(), DOT);
+            list.add(new DateRange(start, end));
         }
-        List<LocalDate> dates = Arrays.stream(dbData.split(DELIMITER))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(LocalDate::parse) // 기본 ISO-8601 파서
-                .collect(Collectors.toList());
-        return ReservationDateList.of(dates);
+        return ReservationDateList.of(list);
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/dto/CursorExtractor.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/CursorExtractor.java
@@ -1,0 +1,6 @@
+package konkuk.chacall.global.common.dto;
+
+@FunctionalInterface
+public interface CursorExtractor<T> {
+    Long extractCursor(T lastElement);
+}

--- a/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
@@ -7,7 +7,12 @@ public record CursorPagingResponse<T>(
         Long lastCursor,
         boolean hasNext
 ) {
-    public static <T> CursorPagingResponse<T> of(List<T> content, Long lastCursor, boolean hasNext) {
+    public static <T> CursorPagingResponse<T> of(
+            List<T> content,
+            CursorExtractor<T> extractor,
+            boolean hasNext
+    ) {
+        Long lastCursor = (content == null || content.isEmpty()) ? null : extractor.extractCursor(content.get(content.size() - 1));
         return new CursorPagingResponse<>(content, lastCursor, hasNext);
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
@@ -4,11 +4,10 @@ import java.util.List;
 
 public record CursorPagingResponse<T>(
         List<T> content,
-        int pageSize,
         Long lastCursor,
         boolean hasNext
 ) {
-    public static <T> CursorPagingResponse<T> of(List<T> content, int pageSize, Long lastCursor, boolean hasNext) {
-        return new CursorPagingResponse<>(content, pageSize, lastCursor, hasNext);
+    public static <T> CursorPagingResponse<T> of(List<T> content, Long lastCursor, boolean hasNext) {
+        return new CursorPagingResponse<>(content, lastCursor, hasNext);
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
@@ -1,0 +1,14 @@
+package konkuk.chacall.global.common.dto;
+
+import java.util.List;
+
+public record CursorPagingResponse<T>(
+        List<T> content,
+        int pageSize,
+        Long lastCursor,
+        boolean hasNext
+) {
+    public static <T> CursorPagingResponse<T> of(List<T> content, int pageSize, Long lastCursor, boolean hasNext) {
+        return new CursorPagingResponse<>(content, pageSize, lastCursor, hasNext);
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/dto/HasPaging.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/HasPaging.java
@@ -1,0 +1,9 @@
+package konkuk.chacall.global.common.dto;
+
+public interface HasPaging {
+    PagingRequest pagingRequest();
+
+    default PagingRequest pagingOrDefault() {
+        return pagingRequest() == null ? new PagingRequest(null, null) : pagingRequest();
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/dto/PagingRequest.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/PagingRequest.java
@@ -1,0 +1,28 @@
+package konkuk.chacall.global.common.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+
+@Schema(description = "커서 기반 페이징 요청 DTO")
+public record PagingRequest(
+        @Schema(description = "마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)",
+                example = "120",
+                nullable = true)
+        Long cursor,
+
+        @Schema(description = "한 페이지에 조회할 개수",
+                defaultValue = "20",
+                minimum = "1")
+        @Min(value = 1, message = "size 는 1 이상이어야 합니다.")
+        Integer size
+) {
+    private static final int DEFAULT_SIZE = 20;
+
+    public long getCursorOrDefault() {
+        return (this.cursor == null) ? Long.MAX_VALUE : this.cursor;
+    }
+
+    public int getSizeOrDefault() {
+        return (this.size == null) ? DEFAULT_SIZE : this.size;
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/dto/PagingRequest.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/PagingRequest.java
@@ -17,12 +17,14 @@ public record PagingRequest(
         Integer size
 ) {
     private static final int DEFAULT_SIZE = 20;
+    private static final long DEFAULT_CURSOR = Long.MAX_VALUE;
 
-    public long getCursorOrDefault() {
-        return (this.cursor == null) ? Long.MAX_VALUE : this.cursor;
-    }
-
-    public int getSizeOrDefault() {
-        return (this.size == null) ? DEFAULT_SIZE : this.size;
+    public PagingRequest {
+        if (cursor == null) {
+            cursor = DEFAULT_CURSOR;
+        }
+        if (size == null) {
+            size = DEFAULT_SIZE;
+        }
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -45,7 +45,12 @@ public enum ErrorCode implements ResponseCode {
     /**
      * ChatTemplate
      */
-    CHAT_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, 80001, "자주 쓰는 채팅을 찾을 수 없습니다.");
+    CHAT_TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, 80001, "자주 쓰는 채팅을 찾을 수 없습니다."),
+
+    /**
+     * Reservation
+     */
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 90001, "예약 내역을 찾을 수 없습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -50,7 +50,9 @@ public enum ErrorCode implements ResponseCode {
     /**
      * Reservation
      */
-    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 90001, "예약 내역을 찾을 수 없습니다.")
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 90001, "예약 내역을 찾을 수 없습니다."),
+    INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 90002, "종료일은 시작일보다 빠를 수 없습니다."),
+    INVALID_DATE_INPUT(HttpStatus.BAD_REQUEST, 90003, "잘못된 날짜 입력 형식입니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -52,7 +52,8 @@ public enum ErrorCode implements ResponseCode {
      */
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, 90001, "예약 내역을 찾을 수 없습니다."),
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 90002, "종료일은 시작일보다 빠를 수 없습니다."),
-    INVALID_DATE_INPUT(HttpStatus.BAD_REQUEST, 90003, "잘못된 날짜 입력 형식입니다.")
+    INVALID_DATE_INPUT(HttpStatus.BAD_REQUEST, 90003, "잘못된 날짜 입력 형식입니다."),
+    RESERVATION_NOT_OWNED(HttpStatus.FORBIDDEN, 90004, "본인 소유 예약이 아닙니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -10,7 +10,7 @@ import static konkuk.chacall.global.common.exception.code.ErrorCode.*;
 
 @Getter
 public enum SwaggerResponseDescription {
-//
+    //
     //Auth
     LOGIN(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND
@@ -56,9 +56,18 @@ public enum SwaggerResponseDescription {
     OWNER_DELETE_CHAT_TEMPLATE(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             CHAT_TEMPLATE_NOT_FOUND
+    ))),
+    OWNER_GET_RESERVATION_HISTORY(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND
+    ))),
+    OWNER_GET_RESERVATION_DETAIL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            RESERVATION_NOT_FOUND
     )))
-  ;
+    ;
+
     private final Set<ErrorCode> errorCodeList;
+
     SwaggerResponseDescription(Set<ErrorCode> errorCodeList) {
         // 공통 에러
         errorCodeList.addAll(new LinkedHashSet<>(Set.of(

--- a/src/main/java/konkuk/chacall/global/config/WebConfig.java
+++ b/src/main/java/konkuk/chacall/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package konkuk.chacall.global.config;
+
+import konkuk.chacall.global.common.security.resolver.UserIdArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final UserIdArgumentResolver userIdArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(userIdArgumentResolver);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #12 

## 📝작업 내용

사장님 - 예약 내역 목록 조회 및 상세 조회 API 를 구현하였습니다.

### 무한스크롤을 위한 공통 DTO 구현
모든 리스트 기반 조회 로직에는 무한스크롤이 적용될 예정이라고 합니다. 따라서 무한스크롤에 필요한 커서, 마지막 페이지 여부 등을 공통으로 관리해주는 DTO 를 구현하였습니다. 이 때 응답에는 pageSize 를 별도로 명시하지 않았습니다. 프론트단에서 따로 활용할 여지가 없다고 판단했기 때문입니다.
 
<img width="794" height="198" alt="스크린샷 2025-09-15 오후 7 00 44" src="https://github.com/user-attachments/assets/0332be56-9d9e-4ce9-8029-9d2aa1168ffd" />

다른 무한스크롤 로직에도 이 dto 를 가져다가 사용하시면 될 것 같습니다

추가로 무한스크롤을 구현할 경우, 동일한 값을 매번 요청에 포함시켜야할 필요성이 존재했습니다. cursor, size 값이 그 대표적인 예시인데, 이 두 가지 값들은 null 을 넘겨줄 경우 서버단에서 자동으로 기본값을 채워주도록 구현하고자 했습니다. 
다만 만약 페이징 관련 요청을 공통되게 처리해주는 dto 가 없다면, 이 기본값 설정 로직을 모든 페이징이 필요한 API의 요청 dto 마다 구현해주어야했습니다.
따라서 그러한 중복 로직을 막고자 PagingRequest 라는 페이징 관련 요청만을 담당하는 DTO 를 따로 만들고, 이 dto 를 실제로 서비스로직에 활용될 요청 DTO 에 포함시키도록 구현하였습니다.

<img width="671" height="510" alt="스크린샷 2025-09-15 오후 8 40 28" src="https://github.com/user-attachments/assets/4dd14acb-b295-4904-8bdb-0eb22c17b097" />
<img width="577" height="264" alt="스크린샷 2025-09-15 오후 8 40 40" src="https://github.com/user-attachments/assets/91ac4da9-a89b-4cf0-b14e-bf91682d3d77" />

따라서 추후 페이징 관련 로직 구현하실 때 이 부분도 참고하시면 좋을 것 같습니다

### 예약 내역 목록 조회

예약 내역 목록 조회에서는 다음과 같은 고민거리가 있었습니다.
하나의 예약에는 최대 2개의 예약 일정이 존재할 수 있고, 오직 한 개의 운영 시간대가 존재한다.
예약 일정은 2개인데 운영 시간대는 하나라서 이 부분을 어떻게 처리해야하나 PM 님께 여쭤보니, 두 일정 모두 하나의 운영 시간대를 따르도록 해주면 된다라는 피드백을 받게 되어서 해당 방식으로 구현을 진행하였습니다.
<img width="648" height="108" alt="스크린샷 2025-09-15 오후 7 03 26" src="https://github.com/user-attachments/assets/82c323e9-696d-48d2-badb-c14357ea7e4d" />

이 때 응답을 손쉽게 만들 수 있도록 ReservationInfo 클래스 내부에 일정 + 운영 시간대를 합쳐서 List 로 반환해주는 메서드를 만들어두었습니다.

추가로 페이징 로직이 들어가다보니 조회시에 fetch join 을 사용할 수 없게 되었습니다. 따라서 N+1 문제를 해결하기 위해 다음과 같은 흐름을 따라주었습니다.

1. **`사장님의 예약 목록을 우선 조회해온다. (페이징) -> 쿼리 1회`**
2. **`조회해온 예약에서 멤버들의 id 들을 추출한 후, 추출한 멤버의 id 를 기반으로 DB에서 해당 id 를 갖는 멤버를 모두 조회한다 -> 쿼리 1회`**
3. **`이렇게 조회해온 데이터들을 기반으로 응답을 내려준다.`**

이 방식이 아니라 실제로 지연 로딩을 활용할  경우, 
1. **`사장님 예약 목록 조회하는 쿼리 1회`**
2. **`각 예약 목록에서 멤버 조회(getMember()) 를 통한 쿼리 N회 (페이지 개수 만큼)`**

가 필요했으나, 위와 같이 로직을 변경함으로써 쿼리 횟수를 2회로 줄였습니다.

### 예약 상세 내역 조회

이 기능은 별다른 이슈는 없었습니다. 그저 reservationId 를 받아 예약 객체를 조회하면 되었는데, 이 때는 별도의 페이징이 존재하지 않기 때문에 fetch join 을 적용함으로써 쿼리가 1회만 발생하도록 구현하였습니다.

### 스크린샷 (선택)
<img width="548" height="327" alt="스크린샷 2025-09-15 오후 8 02 03" src="https://github.com/user-attachments/assets/2ccddc9f-72ca-4ff1-854c-a82bf045de1d" />

<img width="512" height="310" alt="스크린샷 2025-09-15 오후 8 02 19" src="https://github.com/user-attachments/assets/ca832e90-4540-40a3-9e58-c2a7c45f63f5" />


## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 점주용 예약 내역 조회 기능 추가: 예약 상태 필터와 커서 기반 페이징으로 연속 조회 가능.
  - 점주용 예약 상세 조회 추가: 게스트 프로필·이름, 주소, 예약 일시 목록, 메뉴, 보증금, 전기 사용 여부, PDF 링크 및 요청 정보 제공.
- **Documentation**
  - 신규 API 응답 스키마 및 관련 오류 코드(예약 없음·권한·날짜 입력 오류 등) 문서에 반영.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->