### PR TITLE
[FEAT] 예약 견적서 작성, 조회, 수정 api 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
@@ -76,11 +76,11 @@ public class FoodTruck extends BaseEntity {
     private User owner;
 
     private boolean isOwnedBy(Long ownerId) {
-        return this.getOwner().getUserId().equals(ownerId);
+        return this.owner.getUserId().equals(ownerId);
     }
 
     public void validateOwner(Long ownerId) {
-        if (!isOwnedBy(owner.getUserId())) {
+        if (!isOwnedBy(ownerId)) {
             throw new DomainRuleException(ErrorCode.FOOD_TRUCK_NOT_OWNED);
         }
     }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/FoodTruck.java
@@ -6,6 +6,8 @@ import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.converter.MenuCategoryListConverter;
 import konkuk.chacall.global.common.converter.PhotoUrlListConverter;
 import konkuk.chacall.global.common.domain.BaseEntity;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.*;
 
 import java.util.List;
@@ -73,8 +75,14 @@ public class FoodTruck extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 
-    public boolean isOwnedBy(Long ownerId) {
+    private boolean isOwnedBy(Long ownerId) {
         return this.getOwner().getUserId().equals(ownerId);
+    }
+
+    public void validateOwner(Long ownerId) {
+        if (!isOwnedBy(owner.getUserId())) {
+            throw new DomainRuleException(ErrorCode.FOOD_TRUCK_NOT_OWNED);
+        }
     }
 
     public void updateAverageRating(double rating) {

--- a/src/main/java/konkuk/chacall/domain/member/application/MemberService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/MemberService.java
@@ -11,9 +11,11 @@ import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.dto.CursorPagingRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MemberService {
 
     private final SavedFoodTruckService savedFoodTruckService;
@@ -22,6 +24,7 @@ public class MemberService {
 
     private final MemberValidator memberValidator;
 
+    @Transactional
     public SavedFoodTruckStatusResponse updateFoodTruckSaveStatus(UpdateFoodTruckSaveStatusRequest request, Long foodTruckId, Long memberId) {
         // 멤버 유효성 검사 및 조회
         User member = memberValidator.validateAndGetMember(memberId);
@@ -37,6 +40,7 @@ public class MemberService {
         return savedFoodTruckService.getSavedFoodTrucks(cursorPagingRequest, member);
     }
 
+    @Transactional
     public void registerRatings(RegisterRatingRequest request, Long memberId) {
         // 멤버 유효성 검사 및 조회
         User member = memberValidator.validateAndGetMember(memberId);

--- a/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
@@ -23,13 +23,11 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class SavedFoodTruckService {
 
     private final SavedFoodTruckRepository savedFoodTruckRepository;
     private final FoodTruckRepository foodTruckRepository;
 
-    @Transactional
     public SavedFoodTruckStatusResponse updateFoodTruckSaveStatus(UpdateFoodTruckSaveStatusRequest request, Long foodTruckId, User member) {
 
         // 푸드트럭 존재 여부 확인

--- a/src/main/java/konkuk/chacall/domain/member/application/rating/RatingService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/rating/RatingService.java
@@ -18,14 +18,12 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class RatingService {
 
     private final RatingRepository ratingRepository;
     private final FoodTruckRepository foodTruckRepository;
     private final ReservationRepository reservationRepository;
 
-    @Transactional
     public void registerRatings(RegisterRatingRequest request, User member) {
         Reservation reservation = reservationRepository.findById(request.reservationId())
                 .orElseThrow(() -> new BusinessException(ErrorCode.RESERVATION_NOT_FOUND));

--- a/src/main/java/konkuk/chacall/domain/member/application/reservation/MemberReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/reservation/MemberReservationService.java
@@ -41,9 +41,7 @@ public class MemberReservationService {
         Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
 
-        if(!reservation.isReservedBy(member.getUserId())) {
-            throw new BusinessException(ErrorCode.RESERVATION_NOT_OWNED);
-        }
+        reservation.validateReservedBy(member.getUserId());
 
         return MemberReservationDetailResponse.of(reservation, reservation.getFoodTruck());
     }

--- a/src/main/java/konkuk/chacall/domain/member/application/reservation/MemberReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/reservation/MemberReservationService.java
@@ -20,7 +20,6 @@ import java.util.List;
 
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class MemberReservationService {
 
     private final ReservationRepository reservationRepository;

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationDetailResponse.java
@@ -44,7 +44,7 @@ public record MemberReservationDetailResponse(
         return new MemberReservationDetailResponse(
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(),
                 foodTruck.getName(),
-                reservation.getReservationInfo().getReservationAddress(),
+                reservation.getReservationInfo().getAddress(),
                 dateTimeList,
                 reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationDetailResponse.java
@@ -44,7 +44,7 @@ public record MemberReservationDetailResponse(
         return new MemberReservationDetailResponse(
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(),
                 foodTruck.getName(),
-                reservation.getReservationInfo().getAddress(),
+                reservation.getReservationInfo().getFullAddress(),
                 dateTimeList,
                 reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationHistoryResponse.java
@@ -27,7 +27,7 @@ public record MemberReservationHistoryResponse(
                 reservation.getReservationId(),
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(),
                 foodTruck.getName(),
-                reservation.getReservationInfo().getAddress(),
+                reservation.getReservationInfo().getFullAddress(),
                 dateTimeList
         );
     }

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/MemberReservationHistoryResponse.java
@@ -27,7 +27,7 @@ public record MemberReservationHistoryResponse(
                 reservation.getReservationId(),
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(),
                 foodTruck.getName(),
-                reservation.getReservationInfo().getReservationAddress(),
+                reservation.getReservationInfo().getAddress(),
                 dateTimeList
         );
     }

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/ReservationForRatingResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/ReservationForRatingResponse.java
@@ -38,7 +38,7 @@ public record ReservationForRatingResponse(
                     foodTruck.getFoodTruckId(),
                     foodTruck.getName(),
                     foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(), // 대표 사진 (첫 번째 사진)
-                    reservation.getReservationInfo().getAddress(),
+                    reservation.getReservationInfo().getFullAddress(),
                     dateTimeList
             );
         }

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/ReservationForRatingResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/ReservationForRatingResponse.java
@@ -38,7 +38,7 @@ public record ReservationForRatingResponse(
                     foodTruck.getFoodTruckId(),
                     foodTruck.getName(),
                     foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(), // 대표 사진 (첫 번째 사진)
-                    reservation.getReservationInfo().getReservationAddress(),
+                    reservation.getReservationInfo().getAddress(),
                     dateTimeList
             );
         }

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
@@ -55,9 +55,7 @@ public class MyFoodTruckService {
         FoodTruck foodTruck = foodTruckRepository.findById(foodTruckId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
 
-        if (!foodTruck.isOwnedBy(ownerId)) {
-            throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_OWNED);
-        }
+        foodTruck.validateOwner(ownerId);
 
         // 푸드트럭 호출 가능 지역 삭제
         foodTruckServiceAreaRepository.deleteAllByFoodTruckId(foodTruckId);

--- a/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/reservation/OwnerReservationService.java
@@ -48,9 +48,7 @@ public class OwnerReservationService {
         Reservation reservation = reservationRepository.findByIdWithDetails(reservationId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
 
-        if(!reservation.isForFoodTruckOwnedBy(ownerId)) {
-            throw new BusinessException(ErrorCode.RESERVATION_NOT_OWNED);
-        }
+        reservation.validateFoodTruckOwner(ownerId);
 
         // DTO 로 변환하여 반환
         return OwnerReservationDetailResponse.of(reservation, reservation.getMember());

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
@@ -45,7 +45,7 @@ public record OwnerReservationDetailResponse(
         return new OwnerReservationDetailResponse(
                 member.getProfileImageUrl(),
                 member.getName(),
-                reservation.getReservationInfo().getReservationAddress(),
+                reservation.getReservationInfo().getAddress(),
                 dateTimeList,
                 reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
@@ -45,7 +45,7 @@ public record OwnerReservationDetailResponse(
         return new OwnerReservationDetailResponse(
                 member.getProfileImageUrl(),
                 member.getName(),
-                reservation.getReservationInfo().getAddress(),
+                reservation.getReservationInfo().getFullAddress(),
                 dateTimeList,
                 reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
@@ -29,7 +29,7 @@ public record OwnerReservationHistoryResponse(
                 reservation.getReservationId(),
                 member.getProfileImageUrl(),
                 member.getName(),
-                reservation.getReservationInfo().getReservationAddress(),
+                reservation.getReservationInfo().getAddress(),
                 dateTimeList,
                 reservation.getFoodTruck().getName()
         );

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationHistoryResponse.java
@@ -29,7 +29,7 @@ public record OwnerReservationHistoryResponse(
                 reservation.getReservationId(),
                 member.getProfileImageUrl(),
                 member.getName(),
-                reservation.getReservationInfo().getAddress(),
+                reservation.getReservationInfo().getFullAddress(),
                 dateTimeList,
                 reservation.getFoodTruck().getName()
         );

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -24,8 +24,9 @@ public class ReservationService {
     @Transactional
     public Long createReservation(CreateReservationRequest request, Long ownerId) {
         User owner = ownerValidator.validateAndGetOwner(ownerId);
+        User member = memberValidator.validateAndGetMember(request.reservationUserId());
 
-        return reservationInfoService.createReservation(request, owner);
+        return reservationInfoService.createReservation(request, owner, member);
     }
 
     public ReservationResponse getReservation(Long reservationId, Long userId) {

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -4,6 +4,7 @@ import konkuk.chacall.domain.member.application.validator.MemberValidator;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.reservation.application.reservationinfo.ReservationInfoService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
@@ -30,5 +31,11 @@ public class ReservationService {
         User user = memberValidator.validateAndGetMember(userId);
 
         return reservationInfoService.getReservation(reservationId, user);
+    }
+
+    public Long updateReservation(Long reservationId, UpdateReservationRequest request, Long userId) {
+        User user = memberValidator.validateAndGetMember(userId);
+
+        return reservationInfoService.updateReservation(reservationId, request, user);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -1,4 +1,25 @@
 package konkuk.chacall.domain.reservation.application;
 
+import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
+import konkuk.chacall.domain.reservation.application.reservationinfo.ReservationInfoService;
+import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.user.domain.model.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
 public class ReservationService {
+
+    private final ReservationInfoService reservationInfoService;
+
+    private final OwnerValidator ownerValidator;
+
+    @Transactional
+    public Long createReservation(CreateReservationRequest request, Long ownerId) {
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        return reservationInfoService.createReservation(request, owner);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -1,8 +1,10 @@
 package konkuk.chacall.domain.reservation.application;
 
+import konkuk.chacall.domain.member.application.validator.MemberValidator;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.reservation.application.reservationinfo.ReservationInfoService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
 import konkuk.chacall.domain.user.domain.model.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -15,11 +17,18 @@ public class ReservationService {
     private final ReservationInfoService reservationInfoService;
 
     private final OwnerValidator ownerValidator;
+    private final MemberValidator memberValidator;
 
     @Transactional
     public Long createReservation(CreateReservationRequest request, Long ownerId) {
         User owner = ownerValidator.validateAndGetOwner(ownerId);
 
         return reservationInfoService.createReservation(request, owner);
+    }
+
+    public ReservationResponse getReservation(Long reservationId, Long userId) {
+        User user = memberValidator.validateAndGetMember(userId);
+
+        return reservationInfoService.getReservation(reservationId, user);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -13,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReservationService {
 
     private final ReservationInfoService reservationInfoService;
@@ -33,6 +34,7 @@ public class ReservationService {
         return reservationInfoService.getReservation(reservationId, user);
     }
 
+    @Transactional
     public Long updateReservation(Long reservationId, UpdateReservationRequest request, Long userId) {
         User user = memberValidator.validateAndGetMember(userId);
 

--- a/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
@@ -5,6 +5,8 @@ import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
+import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
@@ -22,6 +24,9 @@ public class ReservationInfoService {
         FoodTruck foodTruck = foodTruckRepository.findById(request.foodTruckId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
 
+        // 푸드트럭 소유자 검증
+        foodTruck.validateOwner(owner.getUserId());
+
         Reservation reservation = Reservation.create(
                 request.address(),
                 request.detailAddress(),
@@ -35,5 +40,19 @@ public class ReservationInfoService {
                 foodTruck);
 
         return reservationRepository.save(reservation).getReservationId();
+    }
+
+    public ReservationResponse getReservation(Long reservationId, User user) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        // 예약 소유자 또는 푸드트럭 소유자인지 확인
+        if(user.getRole().equals(Role.OWNER)) {
+            reservation.validateFoodTruckOwner(user.getUserId());
+        } else {
+            reservation.validateReservedBy(user.getUserId());
+        }
+
+        return ReservationResponse.of(reservation);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
@@ -5,6 +5,7 @@ import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.reservation.domain.model.Reservation;
 import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
 import konkuk.chacall.domain.user.domain.model.Role;
 import konkuk.chacall.domain.user.domain.model.User;
@@ -54,5 +55,30 @@ public class ReservationInfoService {
         }
 
         return ReservationResponse.of(reservation);
+    }
+
+    public Long updateReservation(Long reservationId, UpdateReservationRequest request, User user) {
+        Reservation reservation = reservationRepository.findById(reservationId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
+
+        // 예약 소유자 또는 푸드트럭 소유자인지 확인
+        if(user.getRole().equals(Role.OWNER)) {
+            reservation.validateFoodTruckOwner(user.getUserId());
+        } else {
+            reservation.validateReservedBy(user.getUserId());
+        }
+
+        reservation.update(
+                request.address(),
+                request.detailAddress(),
+                request.reservationDates(),
+                request.operationHour(),
+                request.menu(),
+                request.deposit(),
+                request.isUseElectricity(),
+                request.etcRequest()
+        );
+
+        return reservation.getReservationId();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
@@ -1,0 +1,39 @@
+package konkuk.chacall.domain.reservation.application.reservationinfo;
+
+import konkuk.chacall.domain.foodtruck.domain.FoodTruck;
+import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
+import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationInfoService {
+
+    private final FoodTruckRepository foodTruckRepository;
+    private final ReservationRepository reservationRepository;
+
+    public Long createReservation(CreateReservationRequest request, User owner) {
+        FoodTruck foodTruck = foodTruckRepository.findById(request.foodTruckId())
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
+
+        Reservation reservation = Reservation.create(
+                request.address(),
+                request.detailAddress(),
+                request.reservationDates(),
+                request.operationHour(),
+                request.menu(),
+                request.deposit(),
+                request.isUseElectricity(),
+                request.etcRequest(),
+                owner,
+                foodTruck);
+
+        return reservationRepository.save(reservation).getReservationId();
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/reservationinfo/ReservationInfoService.java
@@ -21,12 +21,9 @@ public class ReservationInfoService {
     private final FoodTruckRepository foodTruckRepository;
     private final ReservationRepository reservationRepository;
 
-    public Long createReservation(CreateReservationRequest request, User owner) {
+    public Long createReservation(CreateReservationRequest request, User owner, User member) {
         FoodTruck foodTruck = foodTruckRepository.findById(request.foodTruckId())
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
-
-        // 푸드트럭 소유자 검증
-        foodTruck.validateOwner(owner.getUserId());
 
         Reservation reservation = Reservation.create(
                 request.address(),
@@ -38,6 +35,7 @@ public class ReservationInfoService {
                 request.isUseElectricity(),
                 request.etcRequest(),
                 owner,
+                member,
                 foodTruck);
 
         return reservationRepository.save(reservation).getReservationId();

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -46,12 +46,26 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "food_truck_id", nullable = false)
     private FoodTruck foodTruck;
 
-    public boolean isForFoodTruckOwnedBy(Long ownerId) {
-        return foodTruck.isOwnedBy(ownerId);
+    // 본인이 푸드트럭 소유자인지 검증
+    public void validateFoodTruckOwner(Long ownerId) {
+        if (isForFoodTruckOwnedBy(ownerId)) {
+            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+        }
     }
 
-    public boolean isReservedBy(Long userId) {
-        return this.member.getUserId().equals(userId);
+    private boolean isForFoodTruckOwnedBy(Long ownerId) {
+        return !this.foodTruck.getOwner().getUserId().equals(ownerId);
+    }
+
+    // 본인이 예약자인지 검증
+    public void validateReservedBy(Long memberId) {
+        if (!isReservedBy(memberId)) {
+            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+        }
+    }
+
+    private boolean isReservedBy(Long memberId) {
+        return this.member.getUserId().equals(memberId);
     }
 
     public void validateCanBeRatedBy(User member) {

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -87,9 +87,10 @@ public class Reservation extends BaseEntity {
             boolean isUseElectricity,
             String etcRequest,
             User owner,
+            User member,
             FoodTruck foodTruck
     ) {
-        validateCreateReservation(owner, foodTruck);
+        validateCreateReservation(owner, member, foodTruck);
 
         ReservationInfo reservationInfo = ReservationInfo.builder()
                 .address(reservationAddress)
@@ -103,17 +104,18 @@ public class Reservation extends BaseEntity {
                 .build();
 
         return Reservation.builder()
+                .reservationId(null)
                 .reservationStatus(ReservationStatus.PENDING) // 기본 상태: 예약 대기
                 .reservationInfo(reservationInfo)
                 .pdfUrl(null)
-                .member(owner)
+                .member(member)
                 .foodTruck(foodTruck)
                 .build();
     }
 
-    private static void validateCreateReservation(User owner, FoodTruck foodTruck) {
+    private static void validateCreateReservation(User owner, User member, FoodTruck foodTruck) {
         foodTruck.validateOwner(owner.getUserId());
-        if (foodTruck.getOwner().getUserId().equals(owner.getUserId())) {
+        if (foodTruck.getOwner().getUserId().equals(member.getUserId())) {
             throw new DomainRuleException(CANNOT_RESERVE_OWN_FOOD_TRUCK);
         }
     }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -92,12 +92,12 @@ public class Reservation extends BaseEntity {
         validateCreateReservation(owner, foodTruck);
 
         ReservationInfo reservationInfo = ReservationInfo.builder()
-                .reservationAddress(reservationAddress)
-                .reservationDetailAddress(reservationDetailAddress)
-                .reservationDate(ReservationDateList.fromJson(reservationDateStrings))
+                .address(reservationAddress)
+                .detailAddress(reservationDetailAddress)
+                .reservationDates(ReservationDateList.fromJson(reservationDateStrings))
                 .operationHour(operationHour)
                 .menu(menu)
-                .reservationDeposit(reservationDeposit)
+                .deposit(reservationDeposit)
                 .isUseElectricity(isUseElectricity)
                 .etcRequest(etcRequest)
                 .build();

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -86,9 +86,11 @@ public class Reservation extends BaseEntity {
             Integer reservationDeposit,
             boolean isUseElectricity,
             String etcRequest,
-            User member,
+            User owner,
             FoodTruck foodTruck
     ) {
+        validateCreateReservation(owner, foodTruck);
+
         ReservationInfo reservationInfo = ReservationInfo.builder()
                 .reservationAddress(reservationAddress)
                 .reservationDetailAddress(reservationDetailAddress)
@@ -104,9 +106,16 @@ public class Reservation extends BaseEntity {
                 .reservationStatus(ReservationStatus.PENDING) // 기본 상태: 예약 대기
                 .reservationInfo(reservationInfo)
                 .pdfUrl(null)
-                .member(member)
+                .member(owner)
                 .foodTruck(foodTruck)
                 .build();
+    }
+
+    private static void validateCreateReservation(User owner, FoodTruck foodTruck) {
+        foodTruck.validateOwner(owner.getUserId());
+        if (foodTruck.getOwner().getUserId().equals(owner.getUserId())) {
+            throw new DomainRuleException(CANNOT_RESERVE_OWN_FOOD_TRUCK);
+        }
     }
 
     public void update(

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -108,4 +108,26 @@ public class Reservation extends BaseEntity {
                 .foodTruck(foodTruck)
                 .build();
     }
+
+    public void update(
+            String reservationAddress,
+            String reservationDetailAddress,
+            List<String> reservationDateStrings,
+            String operationHour,
+            String menu,
+            Integer reservationDeposit,
+            boolean isUseElectricity,
+            String etcRequest
+    ) {
+        this.reservationInfo.updateReservationInfo(
+                reservationAddress,
+                reservationDetailAddress,
+                ReservationDateList.fromJson(reservationDateStrings),
+                operationHour,
+                menu,
+                reservationDeposit,
+                isUseElectricity,
+                etcRequest
+        );
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -48,13 +48,13 @@ public class Reservation extends BaseEntity {
 
     // 본인이 푸드트럭 소유자인지 검증
     public void validateFoodTruckOwner(Long ownerId) {
-        if (isForFoodTruckOwnedBy(ownerId)) {
+        if (!isForFoodTruckOwnedBy(ownerId)) {
             throw new DomainRuleException(RESERVATION_NOT_OWNED);
         }
     }
 
     private boolean isForFoodTruckOwnedBy(Long ownerId) {
-        return !this.foodTruck.getOwner().getUserId().equals(ownerId);
+        return this.foodTruck.getOwner().getUserId().equals(ownerId);
     }
 
     // 본인이 예약자인지 검증

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -2,12 +2,15 @@ package konkuk.chacall.domain.reservation.domain.model;
 
 import jakarta.persistence.*;
 import konkuk.chacall.domain.foodtruck.domain.FoodTruck;
+import konkuk.chacall.domain.reservation.domain.value.ReservationDateList;
 import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
 import konkuk.chacall.global.common.exception.DomainRuleException;
 import lombok.*;
+
+import java.util.List;
 
 import static konkuk.chacall.global.common.exception.code.ErrorCode.*;
 
@@ -58,5 +61,37 @@ public class Reservation extends BaseEntity {
         if (this.reservationStatus != ReservationStatus.CONFIRMED) {
             throw new DomainRuleException(CANNOT_RATE_UNCONFIRMED_RESERVATION);
         }
+    }
+
+    public static Reservation create(
+            String reservationAddress,
+            String reservationDetailAddress,
+            List<String> reservationDateStrings,
+            String operationHour,
+            String menu,
+            Integer reservationDeposit,
+            boolean isUseElectricity,
+            String etcRequest,
+            User member,
+            FoodTruck foodTruck
+    ) {
+        ReservationInfo reservationInfo = ReservationInfo.builder()
+                .reservationAddress(reservationAddress)
+                .reservationDetailAddress(reservationDetailAddress)
+                .reservationDate(ReservationDateList.fromJson(reservationDateStrings))
+                .operationHour(operationHour)
+                .menu(menu)
+                .reservationDeposit(reservationDeposit)
+                .isUseElectricity(isUseElectricity)
+                .etcRequest(etcRequest)
+                .build();
+
+        return Reservation.builder()
+                .reservationStatus(ReservationStatus.PENDING) // 기본 상태: 예약 대기
+                .reservationInfo(reservationInfo)
+                .pdfUrl(null)
+                .member(member)
+                .foodTruck(foodTruck)
+                .build();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -6,9 +6,7 @@ import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;
 import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.domain.BaseEntity;
-import konkuk.chacall.global.common.exception.BusinessException;
 import konkuk.chacall.global.common.exception.DomainRuleException;
-import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.*;
 
 import static konkuk.chacall.global.common.exception.code.ErrorCode.*;

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationDateList.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationDateList.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-@Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ReservationDateList {
 
@@ -28,6 +27,10 @@ public class ReservationDateList {
 
     public boolean isEmpty() {
         return ranges == null || ranges.isEmpty();
+    }
+
+    public List<DateRange> getRanges() {
+        return Collections.unmodifiableList(ranges);
     }
 
     @JsonCreator(mode = JsonCreator.Mode.DELEGATING)

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -67,6 +67,10 @@ public class ReservationInfo {
                 .toList();
     }
 
+    public String getFullAddress() {
+        return this.address + " " + this.detailAddress;
+    }
+
     public String parsingIsUserElectricity() {
         return isUseElectricity ? "가능" : "불가능";
     }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -20,14 +20,14 @@ import java.util.List;
 public class ReservationInfo {
 
     @Column(nullable = false)
-    private String reservationAddress; // 주소 (시/동/구)
+    private String address; // 주소 (시/동/구)
 
     @Column(nullable = false)
-    private String reservationDetailAddress; // 상세 주소
+    private String detailAddress; // 상세 주소
 
     @Convert(converter = ReservationDateListConverter.class)
     @Column(nullable = false)
-    private ReservationDateList reservationDate; // 예약 일정
+    private ReservationDateList reservationDates; // 예약 일정
 
     @Column(nullable = false, length = 50)
     private String operationHour; // 운영 시간대
@@ -36,7 +36,7 @@ public class ReservationInfo {
     private String menu;
 
     @Column(nullable = false)
-    private Integer reservationDeposit; // 예약금
+    private Integer deposit; // 예약금
 
     @Column(name = "is_use_electricity", nullable = false)
     private boolean isUseElectricity; // 전기 사용 여부
@@ -50,7 +50,7 @@ public class ReservationInfo {
     public List<String> getFormattedDateTimeInfos() {
         DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
-        return this.reservationDate.getRanges().stream()
+        return this.reservationDates.getRanges().stream()
                 .map(date -> date.startDate().format(DOT) + " ~ " + date.endDate().format(DOT)
                         + " " + this.operationHour)
                 .toList();
@@ -62,7 +62,7 @@ public class ReservationInfo {
     public List<String> getFormattedDateInfos() {
         DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
-        return this.reservationDate.getRanges().stream()
+        return this.reservationDates.getRanges().stream()
                 .map(date -> date.startDate().format(DOT) + " ~ " + date.endDate().format(DOT))
                 .toList();
     }
@@ -72,7 +72,7 @@ public class ReservationInfo {
     }
 
     public String parsingReservationDeposit() {
-        return reservationDeposit + "원";
+        return deposit + "원";
     }
 
     public void updateReservationInfo(
@@ -85,12 +85,12 @@ public class ReservationInfo {
             boolean isUseElectricity,
             String etcRequest
     ) {
-        this.reservationAddress = reservationAddress;
-        this.reservationDetailAddress = reservationDetailAddress;
-        this.reservationDate = reservationDate;
+        this.address = reservationAddress;
+        this.detailAddress = reservationDetailAddress;
+        this.reservationDates = reservationDate;
         this.operationHour = operationHour;
         this.menu = menu;
-        this.reservationDeposit = reservationDeposit;
+        this.deposit = reservationDeposit;
         this.isUseElectricity = isUseElectricity;
         this.etcRequest = etcRequest;
     }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -44,12 +44,26 @@ public class ReservationInfo {
     @Column(length = 1000)
     private String etcRequest; // 기타 요청 사항
 
+    /**
+     * 예약 날짜와 운영 시간을 "YYYY.MM.DD ~ YYYY.MM.DD HH:MM ~ HH:MM" 형식으로 반환
+     */
     public List<String> getFormattedDateTimeInfos() {
         DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
         return this.reservationDate.getRanges().stream()
                 .map(date -> date.startDate().format(DOT) + " ~ " + date.endDate().format(DOT)
                         + " " + this.operationHour)
+                .toList();
+    }
+
+    /**
+     * 예약 날짜를 "YYYY.MM.DD ~ YYYY.MM.DD" 형식으로 반환
+     */
+    public List<String> getFormattedDateInfos() {
+        DateTimeFormatter DOT = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        return this.reservationDate.getRanges().stream()
+                .map(date -> date.startDate().format(DOT) + " ~ " + date.endDate().format(DOT))
                 .toList();
     }
 

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -74,4 +74,24 @@ public class ReservationInfo {
     public String parsingReservationDeposit() {
         return reservationDeposit + "원";
     }
+
+    public void updateReservationInfo(
+            String reservationAddress,
+            String reservationDetailAddress,
+            ReservationDateList reservationDate,
+            String operationHour,
+            String menu,
+            Integer reservationDeposit,
+            boolean isUseElectricity,
+            String etcRequest
+    ) {
+        this.reservationAddress = reservationAddress;
+        this.reservationDetailAddress = reservationDetailAddress;
+        this.reservationDate = reservationDate;
+        this.operationHour = operationHour;
+        this.menu = menu;
+        this.reservationDeposit = reservationDeposit;
+        this.isUseElectricity = isUseElectricity;
+        this.etcRequest = etcRequest;
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationInfo.java
@@ -4,21 +4,26 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
 import konkuk.chacall.global.common.converter.ReservationDateListConverter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.apache.catalina.LifecycleState;
 
-import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
 
 @Getter
-@NoArgsConstructor
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Embeddable
 public class ReservationInfo {
 
     @Column(nullable = false)
-    private String reservationAddress;
+    private String reservationAddress; // 주소 (시/동/구)
+
+    @Column(nullable = false)
+    private String reservationDetailAddress; // 상세 주소
 
     @Convert(converter = ReservationDateListConverter.class)
     @Column(nullable = false)

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationStatus.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/value/ReservationStatus.java
@@ -7,8 +7,14 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum ReservationStatus {
     PENDING("예약 대기"),
-    CONFIRMED("예약 확정"),
-    CANCELLED("예약 취소");
+
+    CONFIRMED("예약 확정 완료"),
+    CONFIRMED_REQUESTED("예약 확정 요청"),
+
+    CANCELLED("예약 취소 완료"),
+    CANCELED_REQUESTED("예약 취소 요청")
+
+    ;
 
     private final String value;
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -1,4 +1,39 @@
 package konkuk.chacall.domain.reservation.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import konkuk.chacall.domain.reservation.application.ReservationService;
+import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationIdResponse;
+import konkuk.chacall.global.common.annotation.UserId;
+import konkuk.chacall.global.common.dto.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Reservation API", description = "예약 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/reservations")
 public class ReservationController {
+
+    private final ReservationService reservationService;
+
+    @Operation(
+            summary = "예약 견적서 작성 (예약 생성)",
+            description = "사장님이 예약 견적서를 작성합니다. 예약 견적서 정보에 따라 예약이 생성됩니다. (예약 상태: 예약 대기)"
+    )
+    @PostMapping
+    public BaseResponse<ReservationIdResponse> createReservation(
+            @RequestBody @Valid final CreateReservationRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(ReservationIdResponse.of(
+                reservationService.createReservation(request, ownerId)
+        ));
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -57,6 +57,7 @@ public class ReservationController {
             summary = "예약 견적서 수정",
             description = "사장님이 작성한 예약 견적서를 수정합니다. 사장님, 일반 유저 모두 수정 가능합니다."
     )
+    @ExceptionDescription(UPDATE_RESERVATION)
     @PutMapping("/{reservationId}")
     public BaseResponse<ReservationIdResponse> updateReservation(
             @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -7,15 +7,12 @@ import jakarta.validation.Valid;
 import konkuk.chacall.domain.reservation.application.ReservationService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationIdResponse;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
-import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static konkuk.chacall.global.common.swagger.SwaggerResponseDescription.*;
 
@@ -39,6 +36,33 @@ public class ReservationController {
     ) {
         return BaseResponse.ok(ReservationIdResponse.of(
                 reservationService.createReservation(request, ownerId)
+        ));
+    }
+
+    @Operation(
+            summary = "예약 견적서 조회",
+            description = "사장님이 작성한 예약 견적서를 조회합니다. 사장님, 일반 유저 모두 조회 가능합니다."
+    )
+    @GetMapping("/{reservationId}")
+    public BaseResponse<ReservationResponse> getReservation(
+            @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
+            @Parameter(hidden = true) @UserId final Long userId
+    ) {
+        return BaseResponse.ok(reservationService.getReservation(reservationId, userId));
+    }
+
+    @Operation(
+            summary = "예약 견적서 수정",
+            description = "사장님이 작성한 예약 견적서를 수정합니다. 사장님, 일반 유저 모두 수정 가능합니다."
+    )
+    @PutMapping("/{reservationId}")
+    public BaseResponse<ReservationIdResponse> updateReservation(
+            @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
+            @RequestBody @Valid final CreateReservationRequest request,
+            @Parameter(hidden = true) @UserId final Long userId
+    ) {
+        return BaseResponse.ok(ReservationIdResponse.of(
+                reservationService.updateReservation(reservationId, request, userId)
         ));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.reservation.application.ReservationService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationIdResponse;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
@@ -59,7 +60,7 @@ public class ReservationController {
     @PutMapping("/{reservationId}")
     public BaseResponse<ReservationIdResponse> updateReservation(
             @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
-            @RequestBody @Valid final CreateReservationRequest request,
+            @RequestBody @Valid final UpdateReservationRequest request,
             @Parameter(hidden = true) @UserId final Long userId
     ) {
         return BaseResponse.ok(ReservationIdResponse.of(

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -7,13 +7,17 @@ import jakarta.validation.Valid;
 import konkuk.chacall.domain.reservation.application.ReservationService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationIdResponse;
+import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
+import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static konkuk.chacall.global.common.swagger.SwaggerResponseDescription.*;
 
 @Tag(name = "Reservation API", description = "예약 관련 API")
 @RestController
@@ -27,6 +31,7 @@ public class ReservationController {
             summary = "예약 견적서 작성 (예약 생성)",
             description = "사장님이 예약 견적서를 작성합니다. 예약 견적서 정보에 따라 예약이 생성됩니다. (예약 상태: 예약 대기)"
     )
+    @ExceptionDescription(CREATE_RESERVATION)
     @PostMapping
     public BaseResponse<ReservationIdResponse> createReservation(
             @RequestBody @Valid final CreateReservationRequest request,

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -43,6 +43,7 @@ public class ReservationController {
             summary = "예약 견적서 조회",
             description = "사장님이 작성한 예약 견적서를 조회합니다. 사장님, 일반 유저 모두 조회 가능합니다."
     )
+    @ExceptionDescription(GET_RESERVATION)
     @GetMapping("/{reservationId}")
     public BaseResponse<ReservationResponse> getReservation(
             @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -10,6 +10,10 @@ public record CreateReservationRequest(
         @NotNull(message = "푸드트럭 ID는 필수 입력 값입니다.")
         Long foodTruckId,
 
+        @Schema(description = "예약자(일반 유저) ID", example = "2")
+        @NotNull(message = "예약자 ID는 필수 입력 값입니다.")
+        Long reservationUserId,
+
         @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
         @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
         String address,

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -1,19 +1,24 @@
 package konkuk.chacall.domain.reservation.presentation.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 
 import java.util.List;
 
 public record CreateReservationRequest(
+        @Schema(description = "푸드트럭 ID", example = "1")
         @NotNull(message = "푸드트럭 ID는 필수 입력 값입니다.")
         Long foodTruckId,
 
+        @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
         @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
         String address,
 
+        @Schema(description = "예약 상세 주소", example = "역삼로 123")
         @NotBlank(message = "예약 상세 주소는 필수 입력 값입니다.")
         String detailAddress,
 
+        @Schema(description = "예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)", example = "[\"2025.09.20 ~ 2025.09.20\", \"2025.09.25 ~ 2025.09.25\"]")
         @NotNull(message = "예약 날짜는 필수 입력 값입니다.")
         @Size(min = 1, max = 2, message = "예약 날짜는 최소 1개, 최대 2개까지 작성 가능합니다.")
         List<@Pattern(
@@ -21,21 +26,26 @@ public record CreateReservationRequest(
                     message = "예약 날짜 형식이 올바르지 않습니다. (예: 2025.09.20 ~ 2025.09.20)"
         ) String> reservationDates,
 
+        @Schema(description = "운영 시간 (형식: HH:MM ~ HH:MM)", example = "15:00 ~ 16:00")
         @NotBlank(message = "운영 시간은 필수 입력 값입니다.")
         @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d) ~ ([01]\\d|2[0-3]):([0-5]\\d)$",
                 message = "운영 시간 형식이 올바르지 않습니다. (예: 15:00 ~ 16:00)")
         String operationHour,
 
+        @Schema(description = "메뉴", example = "떡볶이, 순대, 튀김")
         @NotBlank(message = "메뉴는 필수 입력 값입니다.")
         String menu,
 
+        @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
         Integer deposit,
 
+        @Schema(description = "전기 사용 여부", example = "true")
         @NotNull(message = "전기 사용 여부는 필수 입력 값입니다.")
         Boolean isUseElectricity,
 
+        @Schema(description = "기타 요청 사항", example = "주차 공간이 넓었으면 좋겠습니다.")
         String etcRequest
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -1,0 +1,41 @@
+package konkuk.chacall.domain.reservation.presentation.dto.request;
+
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+public record CreateReservationRequest(
+        @NotNull(message = "푸드트럭 ID는 필수 입력 값입니다.")
+        Long foodTruckId,
+
+        @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
+        String address,
+
+        @NotBlank(message = "예약 상세 주소는 필수 입력 값입니다.")
+        String detailAddress,
+
+        @NotNull(message = "예약 날짜는 필수 입력 값입니다.")
+        @Size(min = 1, max = 2, message = "예약 날짜는 최소 1개, 최대 2개까지 작성 가능합니다.")
+        List<@Pattern(
+                    regexp = "^\\d{4}\\.\\d{2}\\.\\d{2} ~ \\d{4}\\.\\d{2}\\.\\d{2}$",
+                    message = "예약 날짜 형식이 올바르지 않습니다. (예: 2025.09.20 ~ 2025.09.20)"
+        ) String> reservationDates,
+
+        @NotBlank(message = "운영 시간은 필수 입력 값입니다.")
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d) ~ ([01]\\d|2[0-3]):([0-5]\\d)$",
+                message = "운영 시간 형식이 올바르지 않습니다. (예: 15:00 ~ 16:00)")
+        String operationHour,
+
+        @NotBlank(message = "메뉴는 필수 입력 값입니다.")
+        String menu,
+
+        @NotNull(message = "예약금은 필수 입력 값입니다.")
+        @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
+        Integer deposit,
+
+        @NotNull(message = "전기 사용 여부는 필수 입력 값입니다.")
+        Boolean isUseElectricity,
+
+        String etcRequest
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
@@ -1,0 +1,47 @@
+package konkuk.chacall.domain.reservation.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+
+import java.util.List;
+
+public record UpdateReservationRequest(
+        @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
+        @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
+        String address,
+
+        @Schema(description = "예약 상세 주소", example = "역삼로 123")
+        @NotBlank(message = "예약 상세 주소는 필수 입력 값입니다.")
+        String detailAddress,
+
+        @Schema(description = "예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)", example = "[\"2025.09.20 ~ 2025.09.20\", \"2025.09.25 ~ 2025.09.25\"]")
+        @NotNull(message = "예약 날짜는 필수 입력 값입니다.")
+        @Size(min = 1, max = 2, message = "예약 날짜는 최소 1개, 최대 2개까지 작성 가능합니다.")
+        List<@Pattern(
+                regexp = "^\\d{4}\\.\\d{2}\\.\\d{2} ~ \\d{4}\\.\\d{2}\\.\\d{2}$",
+                message = "예약 날짜 형식이 올바르지 않습니다. (예: 2025.09.20 ~ 2025.09.20)"
+        ) String> reservationDates,
+
+        @Schema(description = "운영 시간 (형식: HH:MM ~ HH:MM)", example = "15:00 ~ 16:00")
+        @NotBlank(message = "운영 시간은 필수 입력 값입니다.")
+        @Pattern(regexp = "^([01]\\d|2[0-3]):([0-5]\\d) ~ ([01]\\d|2[0-3]):([0-5]\\d)$",
+                message = "운영 시간 형식이 올바르지 않습니다. (예: 15:00 ~ 16:00)")
+        String operationHour,
+
+        @Schema(description = "메뉴", example = "떡볶이, 순대, 튀김")
+        @NotBlank(message = "메뉴는 필수 입력 값입니다.")
+        String menu,
+
+        @Schema(description = "예약금 (0 이상)", example = "50000")
+        @NotNull(message = "예약금은 필수 입력 값입니다.")
+        @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
+        Integer deposit,
+
+        @Schema(description = "전기 사용 여부", example = "true")
+        @NotNull(message = "전기 사용 여부는 필수 입력 값입니다.")
+        Boolean isUseElectricity,
+
+        @Schema(description = "기타 요청 사항", example = "주차 공간이 넓었으면 좋겠습니다.")
+        String etcRequest
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationIdResponse.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationIdResponse.java
@@ -1,0 +1,12 @@
+package konkuk.chacall.domain.reservation.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ReservationIdResponse(
+        @Schema(description = "생성된 예약 ID", example = "1")
+        Long reservationId
+) {
+    public static ReservationIdResponse of(Long reservationId) {
+        return new ReservationIdResponse(reservationId);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationResponse.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationResponse.java
@@ -38,12 +38,12 @@ public record ReservationResponse(
         public static ReservationResponse of(Reservation reservation) {
                 ReservationInfo reservationInfo = reservation.getReservationInfo();
                 return new ReservationResponse(
-                        reservationInfo.getReservationAddress(),
-                        reservationInfo.getReservationDetailAddress(),
+                        reservationInfo.getAddress(),
+                        reservationInfo.getDetailAddress(),
                         reservationInfo.getFormattedDateInfos(),
                         reservationInfo.getOperationHour(),
                         reservationInfo.getMenu(),
-                        reservationInfo.getReservationDeposit(),
+                        reservationInfo.getDeposit(),
                         reservationInfo.isUseElectricity(),
                         reservationInfo.getEtcRequest()
             );

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationResponse.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationResponse.java
@@ -1,0 +1,51 @@
+package konkuk.chacall.domain.reservation.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.*;
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.reservation.domain.value.ReservationInfo;
+
+import java.util.List;
+
+public record ReservationResponse(
+        @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
+        String address,
+
+        @Schema(description = "예약 상세 주소", example = "역삼로 123")
+        String detailAddress,
+
+        @Schema(description = "예약 날짜 (형식: YYYY.MM.DD ~ YYYY.MM.DD)", example = "[\"2025.09.20 ~ 2025.09.20\", \"2025.09.25 ~ 2025.09.25\"]")
+        List<@Pattern(
+                regexp = "^\\d{4}\\.\\d{2}\\.\\d{2} ~ \\d{4}\\.\\d{2}\\.\\d{2}$",
+                message = "예약 날짜 형식이 올바르지 않습니다. (예: 2025.09.20 ~ 2025.09.20)"
+        ) String> reservationDates,
+
+        @Schema(description = "운영 시간 (형식: HH:MM ~ HH:MM)", example = "15:00 ~ 16:00")
+        String operationHour,
+
+        @Schema(description = "메뉴", example = "떡볶이, 순대, 튀김")
+        String menu,
+
+        @Schema(description = "예약금 (0 이상)", example = "50000")
+        Integer deposit,
+
+        @Schema(description = "전기 사용 여부", example = "true")
+        Boolean isUseElectricity,
+
+        @Schema(description = "기타 요청 사항", example = "주차 공간이 넓었으면 좋겠습니다.")
+        String etcRequest
+) {
+        public static ReservationResponse of(Reservation reservation) {
+                ReservationInfo reservationInfo = reservation.getReservationInfo();
+                return new ReservationResponse(
+                        reservationInfo.getReservationAddress(),
+                        reservationInfo.getReservationDetailAddress(),
+                        reservationInfo.getFormattedDateInfos(),
+                        reservationInfo.getOperationHour(),
+                        reservationInfo.getMenu(),
+                        reservationInfo.getReservationDeposit(),
+                        reservationInfo.isUseElectricity(),
+                        reservationInfo.getEtcRequest()
+            );
+        }
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode implements ResponseCode {
     INVALID_DATE_RANGE(HttpStatus.BAD_REQUEST, 90002, "종료일은 시작일보다 빠를 수 없습니다."),
     INVALID_DATE_INPUT(HttpStatus.BAD_REQUEST, 90003, "잘못된 날짜 입력 형식입니다."),
     RESERVATION_NOT_OWNED(HttpStatus.FORBIDDEN, 90004, "본인 소유 예약이 아닙니다."),
+    CANNOT_RESERVE_OWN_FOOD_TRUCK(HttpStatus.FORBIDDEN, 90005, "본인 소유 푸드트럭은 예약할 수 없습니다."),
 
     /**
      * Rating

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -128,7 +128,14 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             USER_FORBIDDEN,
             FOOD_TRUCK_NOT_FOUND,
+            FOOD_TRUCK_NOT_OWNED,
             INVALID_DATE_INPUT
+    ))),
+    GET_RESERVATION(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            RESERVATION_NOT_FOUND,
+            RESERVATION_NOT_OWNED
     ))),
 
     // Default

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -106,6 +106,14 @@ public enum SwaggerResponseDescription {
             USER_NOT_FOUND,
             USER_FORBIDDEN
     ))),
+
+    // Reservation
+    CREATE_RESERVATION(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_FOUND,
+            INVALID_DATE_INPUT
+    ))),
   ;
     private final Set<ErrorCode> errorCodeList;
 

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -129,6 +129,7 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             FOOD_TRUCK_NOT_FOUND,
             FOOD_TRUCK_NOT_OWNED,
+            CANNOT_RESERVE_OWN_FOOD_TRUCK,
             INVALID_DATE_INPUT
     ))),
     GET_RESERVATION(new LinkedHashSet<>(Set.of(
@@ -136,6 +137,13 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             RESERVATION_NOT_FOUND,
             RESERVATION_NOT_OWNED
+    ))),
+    UPDATE_RESERVATION(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            RESERVATION_NOT_FOUND,
+            RESERVATION_NOT_OWNED,
+            INVALID_DATE_INPUT
     ))),
 
     // Default

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #25 

## 📝작업 내용

기본 cru API이기 때문에 큰 문제는 없었습니다.
다만, 유효성 검증이 api 개발에 주요 고려사항이였습니다!

**예약 견적서 작성**
- 사장님만 가능
- 자기가 소유한 푸드트럭만 가능
- 자기가 소유한 푸드트럭은 예약 불가

**예약 조회**
- 사장님과 일반유저 모두 가능

**예약 수정**
- 사장님과 일반 유저 모두 가능

**리팩토링 내용**
1. Transactional 레이어 수정 (파사드 레벨로 변경)
2. ReservationStatus에 요청을 의미하는 상수 추가
3. ReservationInfo에서 address를 address, detailAddress로 분리 (address: 시/동/구, detailAddress: 상세 주소) => 이에 따라, 기존 예약 내역 조회 api에서 `reservationInfo.getFullAddress()` 메서드를 호출하여 전체 address를 반환하도록 수정했습니다.
4. ReservationInfo에 reservation이 포함된 키워드 컬럼명 수정 (노션 더미데이터 쿼리에도 반영해두었습니다)
5. 엔티티 소유 여부를 판단하는 검증 로직을 도메인 내부에서 동작하도록 캡슐화

### 스크린샷 (선택)
<img width="1047" height="696" alt="스크린샷 2025-09-19 오후 6 13 50" src="https://github.com/user-attachments/assets/570dfc25-2dfb-42fe-a23b-38314c2971dc" />

<img width="1028" height="625" alt="스크린샷 2025-09-19 오후 6 14 27" src="https://github.com/user-attachments/assets/5620024b-73f1-4fbe-a588-ba61b013ffaa" />

<img width="1043" height="720" alt="스크린샷 2025-09-19 오후 6 24 54" src="https://github.com/user-attachments/assets/f001ec57-af4c-4dc0-8603-c0fddaf432c0" />

## 💬리뷰 요구사항(선택)

ReservationDate 객체에서 fromJson이 잘 구현되어 있어서 손쉽게 구현할 수 있었습니다~ shout out to 퐁퐁균

카톡에서 말씀 드렸던 것처럼 dev.yml 파일은 개발 동안에는 ddl-auto: create으로 두도록 하겠습니다!



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 예약 생성/조회/수정 API를 추가했습니다.
  - 예약 상태에 ‘확정 요청’, ‘취소 요청’을 추가하고 문구를 개선했습니다.
  - 본인 소유 푸드트럭은 예약할 수 없도록 제한하고 관련 오류 응답을 제공합니다.
- Refactor
  - 사용자·사장님 예약 내역/상세 응답에서 주소가 전체 주소로 표시되도록 변경했습니다.
- Documentation
  - Swagger에 예약 API와 검증 규칙, 오류 케이스를 추가/보강했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->