### PR TITLE
[FEAT] 예약 상태 변경 및 조회 api 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -42,7 +42,7 @@ public class ReservationService {
     }
 
     @Transactional
-    public Long updateReservation(Long reservationId, UpdateReservationRequest request, Long userId) {
+    public void updateReservation(Long reservationId, UpdateReservationRequest request, Long userId) {
         User user = memberValidator.validateAndGetMember(userId);
 
         return reservationInfoService.updateReservation(reservationId, request, user);

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -45,7 +45,7 @@ public class ReservationService {
     public void updateReservation(Long reservationId, UpdateReservationRequest request, Long userId) {
         User user = memberValidator.validateAndGetMember(userId);
 
-        return reservationInfoService.updateReservation(reservationId, request, user);
+        reservationInfoService.updateReservation(reservationId, request, user);
     }
 
     @Transactional

--- a/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/ReservationService.java
@@ -2,11 +2,16 @@ package konkuk.chacall.domain.reservation.application;
 
 import konkuk.chacall.domain.member.application.validator.MemberValidator;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
-import konkuk.chacall.domain.reservation.application.reservationinfo.ReservationInfoService;
+import konkuk.chacall.domain.reservation.application.info.ReservationInfoService;
+import konkuk.chacall.domain.reservation.application.status.ReservationStatusService;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationStatusRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationStatusResponse;
 import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ReservationService {
 
     private final ReservationInfoService reservationInfoService;
+    private final ReservationStatusService reservationStatusService;
 
     private final OwnerValidator ownerValidator;
     private final MemberValidator memberValidator;
@@ -40,5 +46,29 @@ public class ReservationService {
         User user = memberValidator.validateAndGetMember(userId);
 
         return reservationInfoService.updateReservation(reservationId, request, user);
+    }
+
+    @Transactional
+    public ReservationStatusResponse updateReservationStatus(Long reservationId, UpdateReservationStatusRequest request, Long userId) {
+        switch(request.reservationStatus()) {
+            case CONFIRMED_REQUESTED -> {
+                User member = memberValidator.validateAndGetMember(userId);
+                return reservationStatusService.updateReservationStatusToConfirmedRequested(reservationId, request, member);
+            }
+            case CONFIRMED -> {
+                User owner = ownerValidator.validateAndGetOwner(userId);
+                return reservationStatusService.updateReservationStatusToConfirmed(reservationId, request, owner);
+            }
+            case CANCELLED, CANCELLED_REQUESTED -> {
+                User user = memberValidator.validateAndGetMember(userId);
+                return reservationStatusService.updateReservationStatusToCancelled(reservationId, request, user);
+            }
+            default -> throw new BusinessException(ErrorCode.INVALID_RESERVATION_STATUS);
+        }
+    }
+
+    public ReservationStatusResponse getReservationStatus(Long reservationId, Long userId) {
+        User user = memberValidator.validateAndGetMember(userId);
+        return reservationStatusService.getReservationStatus(reservationId, user);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/info/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/info/ReservationInfoService.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.reservation.application.reservationinfo;
+package konkuk.chacall.domain.reservation.application.info;
 
 import konkuk.chacall.domain.foodtruck.domain.FoodTruck;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;

--- a/src/main/java/konkuk/chacall/domain/reservation/application/info/ReservationInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/info/ReservationInfoService.java
@@ -55,7 +55,7 @@ public class ReservationInfoService {
         return ReservationResponse.of(reservation);
     }
 
-    public Long updateReservation(Long reservationId, UpdateReservationRequest request, User user) {
+    public void updateReservation(Long reservationId, UpdateReservationRequest request, User user) {
         Reservation reservation = reservationRepository.findById(reservationId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND));
 
@@ -76,7 +76,5 @@ public class ReservationInfoService {
                 request.isUseElectricity(),
                 request.etcRequest()
         );
-
-        return reservation.getReservationId();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/application/status/ReservationStatusService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/status/ReservationStatusService.java
@@ -1,0 +1,74 @@
+package konkuk.chacall.domain.reservation.application.status;
+
+import konkuk.chacall.domain.reservation.domain.model.Reservation;
+import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationStatusRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationStatusResponse;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationStatusService {
+
+    private final ReservationRepository reservationRepository;
+
+    public ReservationStatusResponse updateReservationStatusToConfirmedRequested(Long reservationId, UpdateReservationStatusRequest request, User member) {
+
+        Reservation reservation = findReservation(reservationId);
+
+        // CONFIRMED_REQUESTED는 예약자만 가능
+        reservation.validateReservedBy(member.getUserId());
+
+        updateReservationStatus(reservation, request);
+        return new ReservationStatusResponse(reservation.getReservationStatus());
+    }
+
+    public ReservationStatusResponse updateReservationStatusToConfirmed(Long reservationId, UpdateReservationStatusRequest request, User owner) {
+
+        Reservation reservation = findReservation(reservationId);
+
+        // CONFIRMED는 사장님만 가능
+        reservation.validateFoodTruckOwner(owner.getUserId());
+
+        updateReservationStatus(reservation, request);
+        return new ReservationStatusResponse(reservation.getReservationStatus());
+    }
+
+    public ReservationStatusResponse updateReservationStatusToCancelled(Long reservationId, UpdateReservationStatusRequest request, User user) {
+
+        Reservation reservation = findReservation(reservationId);
+
+        // CANCELLED_REQUESTED, CONFIRMED 모두 예약자, 사장님 모두 가능
+        reservation.validateAccessibleBy(user.getUserId());
+
+        updateReservationStatus(reservation, request);
+        return new ReservationStatusResponse(reservation.getReservationStatus());
+    }
+
+    public ReservationStatusResponse getReservationStatus(Long reservationId, User user) {
+        Reservation reservation = findReservation(reservationId);
+
+        // 예약 소유자 또는 푸드트럭 소유자인지 확인
+        reservation.validateAccessibleBy(user.getUserId());
+
+        return new ReservationStatusResponse(reservation.getReservationStatus());
+    }
+
+    // == 공통 Private Methods == //
+    private Reservation findReservation(Long reservationId) {
+        return reservationRepository.findById(reservationId).orElseThrow(
+                () -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND)
+        );
+    }
+
+    private void updateReservationStatus(Reservation reservation, UpdateReservationStatusRequest request) {
+        reservation.updateStatus(request.reservationStatus());
+        reservationRepository.save(reservation);
+    }
+
+
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/application/status/ReservationStatusService.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/application/status/ReservationStatusService.java
@@ -23,7 +23,7 @@ public class ReservationStatusService {
         // CONFIRMED_REQUESTED는 예약자만 가능
         reservation.validateReservedBy(member.getUserId());
 
-        updateReservationStatus(reservation, request);
+        reservation.updateStatus(request.reservationStatus());
         return new ReservationStatusResponse(reservation.getReservationStatus());
     }
 
@@ -34,7 +34,7 @@ public class ReservationStatusService {
         // CONFIRMED는 사장님만 가능
         reservation.validateFoodTruckOwner(owner.getUserId());
 
-        updateReservationStatus(reservation, request);
+        reservation.updateStatus(request.reservationStatus());
         return new ReservationStatusResponse(reservation.getReservationStatus());
     }
 
@@ -45,7 +45,7 @@ public class ReservationStatusService {
         // CANCELLED_REQUESTED, CONFIRMED 모두 예약자, 사장님 모두 가능
         reservation.validateAccessibleBy(user.getUserId());
 
-        updateReservationStatus(reservation, request);
+        reservation.updateStatus(request.reservationStatus());
         return new ReservationStatusResponse(reservation.getReservationStatus());
     }
 
@@ -64,11 +64,5 @@ public class ReservationStatusService {
                 () -> new EntityNotFoundException(ErrorCode.RESERVATION_NOT_FOUND)
         );
     }
-
-    private void updateReservationStatus(Reservation reservation, UpdateReservationStatusRequest request) {
-        reservation.updateStatus(request.reservationStatus());
-        reservationRepository.save(reservation);
-    }
-
 
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -46,6 +46,13 @@ public class Reservation extends BaseEntity {
     @JoinColumn(name = "food_truck_id", nullable = false)
     private FoodTruck foodTruck;
 
+    // 해당 예약과 연관된 사람인지 검증 (사장님, 예약자)
+    public void validateAccessibleBy(Long userId) {
+        if (!isForFoodTruckOwnedBy(userId) && !isReservedBy(userId)) {
+            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+        }
+    }
+
     // 본인이 푸드트럭 소유자인지 검증
     public void validateFoodTruckOwner(Long ownerId) {
         if (!isForFoodTruckOwnedBy(ownerId)) {
@@ -140,5 +147,13 @@ public class Reservation extends BaseEntity {
                 isUseElectricity,
                 etcRequest
         );
+    }
+
+    public void updateStatus(ReservationStatus newStatus) {
+        // status 순서가 올바른지 검증 (PENDING -> CONFIRMED_REQUESTED -> CONFIRMED -> CANCELLED_REQUESTED -> CANCELLED)
+        if (this.reservationStatus.isInValidStatusTransitionFrom(newStatus)) {
+            throw new DomainRuleException(INVALID_RESERVATION_STATUS_TRANSITION);
+        }
+        this.reservationStatus = newStatus;
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/domain/model/Reservation.java
@@ -49,14 +49,16 @@ public class Reservation extends BaseEntity {
     // 해당 예약과 연관된 사람인지 검증 (사장님, 예약자)
     public void validateAccessibleBy(Long userId) {
         if (!isForFoodTruckOwnedBy(userId) && !isReservedBy(userId)) {
-            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+            throw new DomainRuleException(RESERVATION_NOT_OWNED,
+                    new IllegalArgumentException("해당 예약은 사용자의 푸드트럭에 대한 예약도, 사용자가 예약한 내역도 아닙니다."));
         }
     }
 
     // 본인이 푸드트럭 소유자인지 검증
     public void validateFoodTruckOwner(Long ownerId) {
         if (!isForFoodTruckOwnedBy(ownerId)) {
-            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+            throw new DomainRuleException(RESERVATION_NOT_OWNED,
+                    new IllegalArgumentException("해당 예약은 사용자의 푸드트럭에 대한 예약이 아닙니다."));
         }
     }
 
@@ -67,7 +69,8 @@ public class Reservation extends BaseEntity {
     // 본인이 예약자인지 검증
     public void validateReservedBy(Long memberId) {
         if (!isReservedBy(memberId)) {
-            throw new DomainRuleException(RESERVATION_NOT_OWNED);
+            throw new DomainRuleException(RESERVATION_NOT_OWNED,
+                    new IllegalArgumentException("해당 예약은 사용자가 예약한 내역이 아닙니다."));
         }
     }
 

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.reservation.application.ReservationService;
-import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationStatusRequest;

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -5,10 +5,13 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.reservation.application.ReservationService;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
 import konkuk.chacall.domain.reservation.presentation.dto.request.CreateReservationRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationRequest;
+import konkuk.chacall.domain.reservation.presentation.dto.request.UpdateReservationStatusRequest;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationIdResponse;
 import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationResponse;
+import konkuk.chacall.domain.reservation.presentation.dto.response.ReservationStatusResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
@@ -53,6 +56,7 @@ public class ReservationController {
         return BaseResponse.ok(reservationService.getReservation(reservationId, userId));
     }
 
+    //todo 수정 api시에 id 반환안하도록 변경
     @Operation(
             summary = "예약 견적서 수정",
             description = "사장님이 작성한 예약 견적서를 수정합니다. 사장님, 일반 유저 모두 수정 가능합니다."
@@ -67,5 +71,37 @@ public class ReservationController {
         return BaseResponse.ok(ReservationIdResponse.of(
                 reservationService.updateReservation(reservationId, request, userId)
         ));
+    }
+
+    @Operation(
+            summary = "예약 상태 변경",
+            description = "요청에 따라 예약 상태를 변경합니다." +
+                    "예약 상태 변경 순서: 예약 대기 -> 예약 확정 요청 -> 예약 확정 -> 예약 취소 요청 -> 예약 취소"
+    )
+    @ExceptionDescription(UPDATE_RESERVATION_STATUS)
+    @PatchMapping("{reservationId}/status")
+    public BaseResponse<ReservationStatusResponse> updateReservationStatus(
+            @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
+            @RequestBody @Valid final UpdateReservationStatusRequest request,
+            @Parameter(hidden = true) @UserId final Long userId
+    ) {
+        return BaseResponse.ok(
+                reservationService.updateReservationStatus(reservationId, request, userId)
+        );
+    }
+
+    @Operation(
+            summary = "예약 상태 조회",
+            description = "예약 ID로 예약 상태를 조회합니다."
+    )
+    @ExceptionDescription(GET_RESERVATION_STATUS)
+    @GetMapping("/{reservationId}/status")
+    public BaseResponse<ReservationStatusResponse> getReservationStatus(
+            @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
+            @Parameter(hidden = true) @UserId final Long userId
+    ) {
+        return BaseResponse.ok(
+                reservationService.getReservationStatus(reservationId, userId)
+        );
     }
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/ReservationController.java
@@ -55,21 +55,19 @@ public class ReservationController {
         return BaseResponse.ok(reservationService.getReservation(reservationId, userId));
     }
 
-    //todo 수정 api시에 id 반환안하도록 변경
     @Operation(
             summary = "예약 견적서 수정",
             description = "사장님이 작성한 예약 견적서를 수정합니다. 사장님, 일반 유저 모두 수정 가능합니다."
     )
     @ExceptionDescription(UPDATE_RESERVATION)
     @PutMapping("/{reservationId}")
-    public BaseResponse<ReservationIdResponse> updateReservation(
+    public BaseResponse<Void> updateReservation(
             @Parameter(description = "예약 ID", example = "1") @PathVariable final Long reservationId,
             @RequestBody @Valid final UpdateReservationRequest request,
             @Parameter(hidden = true) @UserId final Long userId
     ) {
-        return BaseResponse.ok(ReservationIdResponse.of(
-                reservationService.updateReservation(reservationId, request, userId)
-        ));
+        reservationService.updateReservation(reservationId, request, userId);
+        return BaseResponse.ok(null);
     }
 
     @Operation(

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -46,7 +46,7 @@ public record CreateReservationRequest(
         @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
-        @Digits(integer = 15, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
+        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
         Integer deposit,
 
         @Schema(description = "전기 사용 여부", example = "true")

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -46,7 +46,7 @@ public record CreateReservationRequest(
         @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
-        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
+        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 10자리까지 입력 가능합니다.")
         Integer deposit,
 
         @Schema(description = "전기 사용 여부", example = "true")

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/CreateReservationRequest.java
@@ -16,10 +16,12 @@ public record CreateReservationRequest(
 
         @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
         @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
+        @Size(max = 20, message = "예약 주소는 공백 포함 최대 20자까지 입력 가능합니다.")
         String address,
 
         @Schema(description = "예약 상세 주소", example = "역삼로 123")
         @NotBlank(message = "예약 상세 주소는 필수 입력 값입니다.")
+        @Size(max = 20, message = "예약 상세 주소는 공백 포함 최대 20자까지 입력 가능합니다.")
         String detailAddress,
 
         @Schema(description = "예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)", example = "[\"2025.09.20 ~ 2025.09.20\", \"2025.09.25 ~ 2025.09.25\"]")
@@ -38,11 +40,13 @@ public record CreateReservationRequest(
 
         @Schema(description = "메뉴", example = "떡볶이, 순대, 튀김")
         @NotBlank(message = "메뉴는 필수 입력 값입니다.")
+        @Size(max = 50, message = "메뉴는 공백 포함 최대 50자까지 입력 가능합니다.")
         String menu,
 
         @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
+        @Digits(integer = 15, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
         Integer deposit,
 
         @Schema(description = "전기 사용 여부", example = "true")
@@ -50,6 +54,7 @@ public record CreateReservationRequest(
         Boolean isUseElectricity,
 
         @Schema(description = "기타 요청 사항", example = "주차 공간이 넓었으면 좋겠습니다.")
+        @Size(max = 200, message = "기타 요청 사항은 공백 포함 최대 200자까지 입력 가능합니다.")
         String etcRequest
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
@@ -8,10 +8,12 @@ import java.util.List;
 public record UpdateReservationRequest(
         @Schema(description = "예약 주소 (시/구/동)", example = "서울시 강남구 역삼동")
         @NotBlank(message = "예약 주소는 필수 입력 값입니다.")
+        @Size(max = 20, message = "예약 주소는 공백 포함 최대 20자까지 입력 가능합니다.")
         String address,
 
         @Schema(description = "예약 상세 주소", example = "역삼로 123")
         @NotBlank(message = "예약 상세 주소는 필수 입력 값입니다.")
+        @Size(max = 20, message = "예약 상세 주소는 공백 포함 최대 20자까지 입력 가능합니다.")
         String detailAddress,
 
         @Schema(description = "예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)", example = "[\"2025.09.20 ~ 2025.09.20\", \"2025.09.25 ~ 2025.09.25\"]")
@@ -30,11 +32,13 @@ public record UpdateReservationRequest(
 
         @Schema(description = "메뉴", example = "떡볶이, 순대, 튀김")
         @NotBlank(message = "메뉴는 필수 입력 값입니다.")
+        @Size(max = 50, message = "메뉴는 공백 포함 최대 50자까지 입력 가능합니다.")
         String menu,
 
         @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
+        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
         Integer deposit,
 
         @Schema(description = "전기 사용 여부", example = "true")
@@ -42,6 +46,7 @@ public record UpdateReservationRequest(
         Boolean isUseElectricity,
 
         @Schema(description = "기타 요청 사항", example = "주차 공간이 넓었으면 좋겠습니다.")
+        @Size(max = 200, message = "기타 요청 사항은 공백 포함 최대 200자까지 입력 가능합니다.")
         String etcRequest
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationRequest.java
@@ -38,7 +38,7 @@ public record UpdateReservationRequest(
         @Schema(description = "예약금 (0 이상)", example = "50000")
         @NotNull(message = "예약금은 필수 입력 값입니다.")
         @PositiveOrZero(message = "예약금은 0 이상이어야 합니다.")
-        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 15자리까지 입력 가능합니다.")
+        @Digits(integer = 10, fraction = 0, message = "예약금은 공백 포함 최대 10자리까지 입력 가능합니다.")
         Integer deposit,
 
         @Schema(description = "전기 사용 여부", example = "true")

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationStatusRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationStatusRequest.java
@@ -8,7 +8,7 @@ public record UpdateReservationStatusRequest(
         @Schema(description = "변경할 예약 상태",
                 requiredMode = Schema.RequiredMode.REQUIRED,
                 example = "CONFIRMED",
-                allowableValues = {"CONFIRMED", "CONFIRMED_REQUESTED", "CANCELLED", "CANCELED_REQUESTED"})
+                allowableValues = {"CONFIRMED", "CONFIRMED_REQUESTED", "CANCELLED", "CANCELLED_REQUESTED"})
         @NotNull(message = "예약 상태는 필수 입력 값입니다.")
         ReservationStatus reservationStatus
 ) {

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationStatusRequest.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/request/UpdateReservationStatusRequest.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.domain.reservation.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+
+public record UpdateReservationStatusRequest(
+        @Schema(description = "변경할 예약 상태",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "CONFIRMED",
+                allowableValues = {"CONFIRMED", "CONFIRMED_REQUESTED", "CANCELLED", "CANCELED_REQUESTED"})
+        @NotNull(message = "예약 상태는 필수 입력 값입니다.")
+        ReservationStatus reservationStatus
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationStatusResponse.java
+++ b/src/main/java/konkuk/chacall/domain/reservation/presentation/dto/response/ReservationStatusResponse.java
@@ -1,0 +1,10 @@
+package konkuk.chacall.domain.reservation.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.chacall.domain.reservation.domain.value.ReservationStatus;
+
+public record ReservationStatusResponse(
+        @Schema(description = "예약 상태", example = "CONFIRMED")
+        ReservationStatus reservationStatus
+) {
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -57,6 +57,8 @@ public enum ErrorCode implements ResponseCode {
     INVALID_DATE_INPUT(HttpStatus.BAD_REQUEST, 90003, "잘못된 날짜 입력 형식입니다."),
     RESERVATION_NOT_OWNED(HttpStatus.FORBIDDEN, 90004, "본인 소유 예약이 아닙니다."),
     CANNOT_RESERVE_OWN_FOOD_TRUCK(HttpStatus.FORBIDDEN, 90005, "본인 소유 푸드트럭은 예약할 수 없습니다."),
+    INVALID_RESERVATION_STATUS(HttpStatus.BAD_REQUEST, 90006, "유효하지 않은 예약 상태입니다."),
+    INVALID_RESERVATION_STATUS_TRANSITION(HttpStatus.BAD_REQUEST, 90007, "유효하지 않은 예약 상태 전환입니다."),
 
     /**
      * Rating

--- a/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
+++ b/src/main/java/konkuk/chacall/global/common/security/resolver/UserIdArgumentResolver.java
@@ -33,8 +33,7 @@ public class UserIdArgumentResolver implements HandlerMethodArgumentResolver {
 
         Object userId = ((HttpServletRequest) webRequest.getNativeRequest()).getAttribute(JWT_ACCESS_TOKEN_KEY.getValue());
         if (userId == null) {
-            return 1L; // 개발동안만 임시로 1L 반환
-            // throw new AuthException(AUTH_TOKEN_NOT_FOUND);
+            throw new AuthException(AUTH_TOKEN_NOT_FOUND);
         }
         return (Long) userId;
     }

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -145,6 +145,20 @@ public enum SwaggerResponseDescription {
             RESERVATION_NOT_OWNED,
             INVALID_DATE_INPUT
     ))),
+    UPDATE_RESERVATION_STATUS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            RESERVATION_NOT_FOUND,
+            RESERVATION_NOT_OWNED,
+            INVALID_RESERVATION_STATUS,
+            INVALID_RESERVATION_STATUS_TRANSITION
+    ))),
+    GET_RESERVATION_STATUS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            RESERVATION_NOT_FOUND,
+            RESERVATION_NOT_OWNED
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())

--- a/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
@@ -81,10 +81,10 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth   // 개발시동안 임시로 모든 경로 허용
                         .requestMatchers("/**").permitAll()
                 )
-//                .authorizeHttpRequests(auth -> auth
-//                        .requestMatchers(WHITELIST).permitAll()
-//                        .anyRequest().authenticated()
-//                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(WHITELIST).permitAll()
+                        .anyRequest().authenticated()
+                )
                 .exceptionHandling(handler -> handler.authenticationEntryPoint(jwtAuthenticationEntryPoint))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 


### PR DESCRIPTION
## #️⃣연관된 이슈

closes #29 

## 📝작업 내용

**예약 상태 변경 api**
1. 변경 요청받은 예약 상태에 따라 파사드 클래스에서 유저 권한을 검증 후 알맞은 하위 클래스 호출
2. Reservation 조회
3. 해당 유저가 예약 상태를 변경할 권한을 가지고 있는지 검증
4. ReservationStatus 순서가 올바른지 검증
5. ReservationStatus 업데이트

4번 과정에서 순서를 보장할 때 초기에 if문으로 분기를 만들어 구현했는데, 추후에 요구사항 수정에 유연하지 못할 것 같아 EnumMap을 만들어 해당 Enum의 가능한 다음 Enum을 Set 자료구조로 주입하여 사용하였습니다.
<img width="788" height="487" alt="스크린샷 2025-09-22 오후 4 46 25" src="https://github.com/user-attachments/assets/2395df77-1167-4f6d-96d7-a7b76edd2285" />

**예약 상태 조회 api**
별다른 이슈가 없습니다.

### 스크린샷

<img width="1046" height="512" alt="스크린샷 2025-09-22 오후 4 51 09" src="https://github.com/user-attachments/assets/a04e6089-4df8-4fab-8c12-b08a3041625c" />


## 💬리뷰 요구사항(선택)

- 추가적으로 프론트 개발자 분들 요청에 따라 다시 userId를 필터에서 주입하도록 수정하였습니다.
- 요구사항에 따라 예약 견적서 작성시 글자수 제한을 추가하였습니다.
- 프론트 개발자 분께 여쭤본 결과 예약 견적서 수정시에는 id 반환이 필요하지 않다고 해서 반환을 제거하였습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 예약 상태 조회/변경 API 추가(역할 기반 전환 검증, 상태 DTO 및 상태 전이 로직 반영).
- Bug Fixes / Validation
  - 예약 생성/수정 입력 유효성 강화(문자 길이, 금액 자릿수 등).
- Refactor
  - 예약 수정 API 응답을 본문 없는 형태로 단순화; 내부 상태 업데이트 흐름 분리.
- Security
  - 화이트리스트 외 모든 요청에 인증 필수, 토큰 누락 시 즉시 인증 오류 반환.
- Documentation
  - 예약 상태 관련 Swagger 문서 및 신규 오류 코드(상태/전환 관련) 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->