### PR TITLE
[FEAT] 푸드트럭과 메뉴 이미지 presiged URL 발급 api 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -1,7 +1,6 @@
 package konkuk.chacall.domain.foodtruck.application;
 
 import konkuk.chacall.domain.foodtruck.application.image.FoodTruckImageService;
-import konkuk.chacall.domain.foodtruck.application.search.FoodTruckSearchService;
 import konkuk.chacall.domain.foodtruck.application.command.FoodTruckCommandService;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckNameDuplicateCheckRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
@@ -12,7 +11,6 @@ import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
 import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.member.application.validator.MemberValidator;
-import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -1,8 +1,13 @@
 package konkuk.chacall.domain.foodtruck.application;
 
+import konkuk.chacall.domain.foodtruck.application.image.FoodTruckImageService;
 import konkuk.chacall.domain.foodtruck.application.search.FoodTruckSearchService;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.ImageRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
+import konkuk.chacall.domain.owner.application.validator.OwnerValidator;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,8 +19,23 @@ import org.springframework.transaction.annotation.Transactional;
 public class FoodTruckService {
 
     private final FoodTruckSearchService foodTruckSearchService;
+    private final FoodTruckImageService foodTruckImageService;
+
+    private final OwnerValidator ownerValidator;
 
     public CursorPagingResponse<FoodTruckResponse> getFoodTrucks(FoodTruckSearchRequest request) {
         return foodTruckSearchService.getFoodTrucks(request);
+    }
+
+    public ImageResponse createFoodTruckImagePresignedUrl(ImageRequest request, Long ownerId) {
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        return foodTruckImageService.createFoodTruckImagePresignedUrl(request, owner);
+    }
+
+    public ImageResponse createMenuImagePresignedUrl(ImageRequest request, Long ownerId) {
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        return foodTruckImageService.createMenuImagePresignedUrl(request, owner);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
@@ -1,0 +1,59 @@
+package konkuk.chacall.domain.foodtruck.application.image;
+
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.ImageRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
+import konkuk.chacall.domain.user.domain.model.User;
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import konkuk.chacall.global.common.storage.S3Service;
+import konkuk.chacall.global.common.storage.util.AllowedFileExtension;
+import konkuk.chacall.global.common.storage.util.KeyUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FoodTruckImageService {
+
+    private final S3Service s3Service;
+    private static final int MAX_FOOD_TRUCK_IMAGE_COUNT = 9;
+//    private static final int MAX_MENU_IMAGE_COUNT = 5;
+
+    public ImageResponse createFoodTruckImagePresignedUrl(ImageRequest request, User owner) {
+        List<String> fileExtensions = request.fileExtensions();
+
+        if(fileExtensions == null || fileExtensions.isEmpty() || fileExtensions.size() > MAX_FOOD_TRUCK_IMAGE_COUNT) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_COUNT,
+                    new IllegalArgumentException("푸드트럭 이미지는 1장 이상 " + MAX_FOOD_TRUCK_IMAGE_COUNT + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + (fileExtensions == null ? 0 : fileExtensions.size())));
+        }
+
+        AllowedFileExtension.checkAllowedExtension(fileExtensions);
+
+        List<String> presignedUrls = fileExtensions.stream()
+                .map(extension -> KeyUtils.buildFoodTruckImageKey(owner.getUserId()))
+                .map(s3Service::generatePresignedUrl)
+                .toList();
+
+        return ImageResponse.of(presignedUrls);
+    }
+
+    public ImageResponse createMenuImagePresignedUrl(ImageRequest request, User owner) {
+        List<String> fileExtensions = request.fileExtensions();
+
+        if(fileExtensions == null || fileExtensions.isEmpty()) {
+            throw new BusinessException(ErrorCode.INVALID_IMAGE_COUNT,
+                    new IllegalArgumentException("메뉴 이미지는 1장 이상 " + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + (fileExtensions == null ? 0 : fileExtensions.size())));
+        }
+
+        AllowedFileExtension.checkAllowedExtension(fileExtensions);
+
+        List<String> presignedUrls = fileExtensions.stream()
+                .map(extension -> KeyUtils.buildMenuImageKey(owner.getUserId()))
+                .map(s3Service::generatePresignedUrl)
+                .toList();
+
+        return ImageResponse.of(presignedUrls);
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
@@ -24,7 +24,7 @@ public class FoodTruckImageService {
     public ImageResponse createFoodTruckImagePresignedUrl(ImageRequest request, User owner) {
         List<String> fileExtensions = request.fileExtensions();
 
-        if(fileExtensions == null || fileExtensions.isEmpty() || fileExtensions.size() > MAX_FOOD_TRUCK_IMAGE_COUNT) {
+        if(fileExtensions.size() > MAX_FOOD_TRUCK_IMAGE_COUNT) {
             throw new BusinessException(ErrorCode.INVALID_IMAGE_COUNT,
                     new IllegalArgumentException("푸드트럭 이미지는 1장 이상 " + MAX_FOOD_TRUCK_IMAGE_COUNT + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + (fileExtensions == null ? 0 : fileExtensions.size())));
         }
@@ -41,11 +41,6 @@ public class FoodTruckImageService {
 
     public ImageResponse createMenuImagePresignedUrl(ImageRequest request, User owner) {
         List<String> fileExtensions = request.fileExtensions();
-
-        if(fileExtensions == null || fileExtensions.isEmpty()) {
-            throw new BusinessException(ErrorCode.INVALID_IMAGE_COUNT,
-                    new IllegalArgumentException("메뉴 이미지는 1장 이상 " + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + (fileExtensions == null ? 0 : fileExtensions.size())));
-        }
 
         AllowedFileExtension.checkAllowedExtension(fileExtensions);
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/image/FoodTruckImageService.java
@@ -26,17 +26,24 @@ public class FoodTruckImageService {
 
         if(fileExtensions.size() > MAX_FOOD_TRUCK_IMAGE_COUNT) {
             throw new BusinessException(ErrorCode.INVALID_IMAGE_COUNT,
-                    new IllegalArgumentException("푸드트럭 이미지는 1장 이상 " + MAX_FOOD_TRUCK_IMAGE_COUNT + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + (fileExtensions == null ? 0 : fileExtensions.size())));
+                    new IllegalArgumentException("푸드트럭 이미지는 1장 이상 " + MAX_FOOD_TRUCK_IMAGE_COUNT + "장 이하로 등록해야 합니다. 입력된 이미지 개수: " + fileExtensions.size()));
         }
 
         AllowedFileExtension.checkAllowedExtension(fileExtensions);
 
-        List<String> presignedUrls = fileExtensions.stream()
-                .map(extension -> KeyUtils.buildFoodTruckImageKey(owner.getUserId()))
-                .map(s3Service::generatePresignedUrl)
+        var imageInfos = fileExtensions.stream()
+                .map(extension -> {
+                    String baseKey = KeyUtils.buildFoodTruckImageKey(owner.getUserId());
+                    String keyWithExt = baseKey + "." + extension.toLowerCase();
+
+                    String presignedUrl = s3Service.generatePresignedUrl(keyWithExt);
+                    String fileUrl = s3Service.getFileUrl(keyWithExt);
+
+                    return ImageResponse.ImageInfo.of(presignedUrl, fileUrl);
+                })
                 .toList();
 
-        return ImageResponse.of(presignedUrls);
+        return ImageResponse.of(imageInfos);
     }
 
     public ImageResponse createMenuImagePresignedUrl(ImageRequest request, User owner) {
@@ -44,11 +51,18 @@ public class FoodTruckImageService {
 
         AllowedFileExtension.checkAllowedExtension(fileExtensions);
 
-        List<String> presignedUrls = fileExtensions.stream()
-                .map(extension -> KeyUtils.buildMenuImageKey(owner.getUserId()))
-                .map(s3Service::generatePresignedUrl)
+        var imageInfos = fileExtensions.stream()
+                .map(extension -> {
+                    String baseKey = KeyUtils.buildMenuImageKey(owner.getUserId());
+                    String keyWithExt = baseKey + "." + extension.toLowerCase();
+
+                    String presignedUrl = s3Service.generatePresignedUrl(keyWithExt);
+                    String fileUrl = s3Service.getFileUrl(keyWithExt);
+
+                    return ImageResponse.ImageInfo.of(presignedUrl, fileUrl);
+                })
                 .toList();
 
-        return ImageResponse.of(presignedUrls);
+        return ImageResponse.of(imageInfos);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -61,6 +61,7 @@ public class FoodTruckController {
             summary = "푸드트럭 이미지 presigned URL 발급",
             description = "푸드트럭 사진을 업로드하기 위한 presigned URL을 발급받습니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_PRESGIEND_URL)
     @PostMapping("/images")
     public BaseResponse<ImageResponse> createFoodTruckImagePresignedUrl(
             @Valid @RequestBody final ImageRequest request,
@@ -73,6 +74,7 @@ public class FoodTruckController {
             summary = "메뉴 이미지 presigned URL 발급",
             description = "메뉴 사진을 업로드하기 위한 presigned URL을 발급받습니다."
     )
+    @ExceptionDescription(SwaggerResponseDescription.GET_MENU_PRESGIEND_URL)
     @PostMapping("/menus/images")
     public BaseResponse<ImageResponse> createMenuImagePresignedUrl(
             @Valid @RequestBody final ImageRequest request,

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -61,7 +61,7 @@ public class FoodTruckController {
             summary = "푸드트럭 이미지 presigned URL 발급",
             description = "푸드트럭 사진을 업로드하기 위한 presigned URL을 발급받습니다."
     )
-    @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_PRESGIEND_URL)
+    @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_PRESIGEND_URL)
     @PostMapping("/images")
     public BaseResponse<ImageResponse> createFoodTruckImagePresignedUrl(
             @Valid @RequestBody final ImageRequest request,
@@ -74,7 +74,7 @@ public class FoodTruckController {
             summary = "메뉴 이미지 presigned URL 발급",
             description = "메뉴 사진을 업로드하기 위한 presigned URL을 발급받습니다."
     )
-    @ExceptionDescription(SwaggerResponseDescription.GET_MENU_PRESGIEND_URL)
+    @ExceptionDescription(SwaggerResponseDescription.GET_MENU_PRESIGEND_URL)
     @PostMapping("/menus/images")
     public BaseResponse<ImageResponse> createMenuImagePresignedUrl(
             @Valid @RequestBody final ImageRequest request,

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -1,21 +1,23 @@
 package konkuk.chacall.domain.foodtruck.presentation;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.foodtruck.application.FoodTruckService;
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.ImageRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
+import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "FoodTruck API", description = "푸드트럭 관련 API")
 @RestController
@@ -34,7 +36,32 @@ public class FoodTruckController {
     @GetMapping
     public BaseResponse<CursorPagingResponse<FoodTruckResponse>> getFoodTrucks(
             @Valid @ParameterObject final FoodTruckSearchRequest request
-            ) {
+    ) {
         return BaseResponse.ok(foodTruckService.getFoodTrucks(request));
     }
+
+    @Operation(
+            summary = "푸드트럭 이미지 presigned URL 발급",
+            description = "푸드트럭 사진을 업로드하기 위한 presigned URL을 발급받습니다."
+    )
+    @PostMapping("/images")
+    public BaseResponse<ImageResponse> createFoodTruckImagePresignedUrl(
+            @Valid @RequestBody final ImageRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(foodTruckService.createFoodTruckImagePresignedUrl(request, ownerId));
+    }
+
+    @Operation(
+            summary = "메뉴 이미지 presigned URL 발급",
+            description = "메뉴 사진을 업로드하기 위한 presigned URL을 발급받습니다."
+    )
+    @PostMapping("/menus/images")
+    public BaseResponse<ImageResponse> createMenuImagePresignedUrl(
+            @Valid @RequestBody final ImageRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        return BaseResponse.ok(foodTruckService.createMenuImagePresignedUrl(request, ownerId));
+    }
+
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/ImageRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/ImageRequest.java
@@ -1,0 +1,17 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record ImageRequest(
+    @Schema(description = "파일 확장자 리스트", example = "[\"png\", \"jpg\"]")
+    @NotNull(message = "파일 확장자는 필수입니다.")
+    @Size(min = 1, message = "최소 하나 이상의 파일 확장자를 제공해야 합니다.")
+    List<String> fileExtensions
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/ImageRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/ImageRequest.java
@@ -1,8 +1,6 @@
 package konkuk.chacall.domain.foodtruck.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
@@ -6,9 +6,21 @@ import java.util.List;
 
 public record ImageResponse(
         @Schema(description = "생성된 presigned URL 리스트", example = "[\"https://example.com/presigned-url1\", \"https://example.com/presigned-url2\"]")
-        List<String> presignedUrls
+        List<ImageInfo> presignedUrls
 ) {
-    public static ImageResponse of(List<String> presignedUrls) {
-        return new ImageResponse(presignedUrls);
+    public record ImageInfo(
+            @Schema(description = "생성된 presigned URL", example = "https://example.com/presigned-url")
+            String presignedUrl,
+
+            @Schema(description = "파일 접근 URL", example = "https://example.com/file-url")
+            String fileUrl
+    ) {
+        public static ImageInfo of(String presignedUrl, String fileUrl) {
+            return new ImageInfo(presignedUrl, fileUrl);
+        }
+    }
+
+    public static ImageResponse of(List<ImageInfo> imageInfos) {
+        return new ImageResponse(imageInfos);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
@@ -1,8 +1,11 @@
 package konkuk.chacall.domain.foodtruck.presentation.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.util.List;
 
 public record ImageResponse(
+        @Schema(description = "생성된 presigned URL 리스트", example = "[\"https://example.com/presigned-url1\", \"https://example.com/presigned-url2\"]")
         List<String> presignedUrls
 ) {
     public static ImageResponse of(List<String> presignedUrls) {

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/ImageResponse.java
@@ -1,0 +1,11 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.response;
+
+import java.util.List;
+
+public record ImageResponse(
+        List<String> presignedUrls
+) {
+    public static ImageResponse of(List<String> presignedUrls) {
+        return new ImageResponse(presignedUrls);
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -77,6 +77,8 @@ public enum ErrorCode implements ResponseCode {
     FOOD_TRUCK_NOT_FOUND(HttpStatus.NOT_FOUND, 110001, "푸드트럭을 찾을 수 없습니다."),
     FOOD_TRUCK_NOT_OWNED(HttpStatus.FORBIDDEN, 110002, "해당 푸드트럭의 소유자가 아닙니다."),
 
+    INVALID_IMAGE_COUNT(HttpStatus.BAD_REQUEST, 115001, "이미지 개수가 유효하지 않습니다."),
+    INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, 115002, "허용되지 않는 파일 확장자입니다."),
 
     /**
      * SavedFoodTruck

--- a/src/main/java/konkuk/chacall/global/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/chacall/global/common/security/filter/JwtAuthenticationFilter.java
@@ -93,6 +93,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/auth/users")
                 || path.equals("/auth/token")
                 || path.startsWith("/index.html")
+                || path.startsWith("/test/token")
                 ;
     }
 

--- a/src/main/java/konkuk/chacall/global/common/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/konkuk/chacall/global/common/security/filter/JwtAuthenticationFilter.java
@@ -28,6 +28,7 @@ import static konkuk.chacall.global.common.security.constant.AuthParameters.*;
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtil jwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -46,11 +47,11 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             Authentication authToken = new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities());
             SecurityContextHolder.getContext().setAuthentication(authToken);
+            filterChain.doFilter(request, response);
         } catch (Exception e) {
             log.error("JWT 필터에서 오류 발생: {}", e.getMessage());
             request.setAttribute("exception", e);
-        } finally {
-            filterChain.doFilter(request, response);
+            jwtAuthenticationEntryPoint.commence(request, response, null);
         }
     }
 

--- a/src/main/java/konkuk/chacall/global/common/storage/S3Service.java
+++ b/src/main/java/konkuk/chacall/global/common/storage/S3Service.java
@@ -1,5 +1,6 @@
 package konkuk.chacall.global.common.storage;
 
+import konkuk.chacall.global.common.storage.util.CdnUrlResolver;
 import konkuk.chacall.global.config.S3Config;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +24,8 @@ public class S3Service {
     private final S3Client s3Client;
     private final S3Presigner s3Presigner;
     private final S3Config s3Config;
+
+    private final CdnUrlResolver cdnUrlResolver;
 
     private static final int PRESIGNED_URL_EXPIRATION_MINUTES = 10;
 
@@ -61,5 +64,9 @@ public class S3Service {
         );
 
         return presignedRequest.url().toString();
+    }
+
+    public String getFileUrl(String key) {
+        return cdnUrlResolver.resolve(key);
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/storage/util/AllowedFileExtension.java
+++ b/src/main/java/konkuk/chacall/global/common/storage/util/AllowedFileExtension.java
@@ -23,13 +23,13 @@ public enum AllowedFileExtension {
 
     public static void checkAllowedExtension(List<String> extensions) {
         for (String extension : extensions) {
-            boolean isMatch = Arrays.stream(AllowedFileExtension.values())
-                    .anyMatch(allowedExtension -> allowedExtension.value.equalsIgnoreCase(extension));
-
-            if (!isMatch) {
-                throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION,
-                        new IllegalArgumentException("허용되지 않은 파일 확장자: " + extension));
-            }
+            Arrays.stream(AllowedFileExtension.values())
+                    .filter(ext -> ext.value.equalsIgnoreCase(extension))
+                    .findAny()
+                    .orElseThrow(() -> new BusinessException(
+                            ErrorCode.INVALID_FILE_EXTENSION,
+                            new IllegalArgumentException("허용되지 않은 파일 확장자: " + extension)
+                    ));
         }
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/storage/util/AllowedFileExtension.java
+++ b/src/main/java/konkuk/chacall/global/common/storage/util/AllowedFileExtension.java
@@ -1,0 +1,35 @@
+package konkuk.chacall.global.common.storage.util;
+
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+
+import java.util.Arrays;
+import java.util.List;
+
+public enum AllowedFileExtension {
+    PNG("png"),
+    JPG("jpg"),
+    JPEG("jpeg"),
+    SVG("svg"),
+    WEBP("webp"),
+    PDF("pdf")
+    ;
+
+    private final String value;
+
+    AllowedFileExtension(String value) {
+        this.value = value;
+    }
+
+    public static void checkAllowedExtension(List<String> extensions) {
+        for (String extension : extensions) {
+            boolean isMatch = Arrays.stream(AllowedFileExtension.values())
+                    .anyMatch(allowedExtension -> allowedExtension.value.equalsIgnoreCase(extension));
+
+            if (!isMatch) {
+                throw new BusinessException(ErrorCode.INVALID_FILE_EXTENSION,
+                        new IllegalArgumentException("허용되지 않은 파일 확장자: " + extension));
+            }
+        }
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/storage/util/KeyUtils.java
+++ b/src/main/java/konkuk/chacall/global/common/storage/util/KeyUtils.java
@@ -4,6 +4,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.UUID;
 
 @NoArgsConstructor(access = lombok.AccessLevel.PRIVATE)
 public final class KeyUtils {
@@ -18,5 +19,23 @@ public final class KeyUtils {
                 RESERVATION_ESTIMATE_PREFIX,
                 timestamp,
                 reservationId);
+    }
+
+    public static String buildFoodTruckImageKey(Long userId) {
+        String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER); // ex) 20250923-163045
+        String uuid = UUID.randomUUID().toString();
+        return String.format("foodtrucks/%d/%s/%s",
+                userId,
+                timestamp,
+                uuid); // foodtrucks/{userId}/{timestamp}/{uuid}
+    }
+
+    public static String buildMenuImageKey(Long foodTruckId) {
+        String timestamp = LocalDateTime.now().format(DATE_TIME_FORMATTER); // ex) 20250923-163045
+        String uuid = UUID.randomUUID().toString();
+        return String.format("menus/%d/%s/%s",
+                foodTruckId,
+                timestamp,
+                uuid); // menus/{foodTruckId}/{timestamp}/{uuid}
     }
 }

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -182,6 +182,18 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_FOUND,
             INVALID_FOOD_TRUCK_STATUS_TRANSITION
     ))),
+    GET_FOOD_TRUCK_PRESGIEND_URL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            INVALID_IMAGE_COUNT,
+            INVALID_FILE_EXTENSION
+    ))),
+    GET_MENU_PRESGIEND_URL(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            INVALID_IMAGE_COUNT,
+            INVALID_FILE_EXTENSION
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -191,7 +191,6 @@ public enum SwaggerResponseDescription {
     GET_MENU_PRESIGEND_URL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             USER_FORBIDDEN,
-            INVALID_IMAGE_COUNT,
             INVALID_FILE_EXTENSION
     ))),
 

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -182,13 +182,13 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_FOUND,
             INVALID_FOOD_TRUCK_STATUS_TRANSITION
     ))),
-    GET_FOOD_TRUCK_PRESGIEND_URL(new LinkedHashSet<>(Set.of(
+    GET_FOOD_TRUCK_PRESIGEND_URL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             USER_FORBIDDEN,
             INVALID_IMAGE_COUNT,
             INVALID_FILE_EXTENSION
     ))),
-    GET_MENU_PRESGIEND_URL(new LinkedHashSet<>(Set.of(
+    GET_MENU_PRESIGEND_URL(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             USER_FORBIDDEN,
             INVALID_IMAGE_COUNT,

--- a/src/main/java/konkuk/chacall/global/config/S3Config.java
+++ b/src/main/java/konkuk/chacall/global/config/S3Config.java
@@ -1,21 +1,23 @@
 package konkuk.chacall.global.config;
 
+import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
-import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.EnvironmentVariableCredentialsProvider;
-import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
-public class AwsConfig {
+public class S3Config {
 
     @Value("${cloud.aws.region.static}")
     private String region;
+
+    @Getter
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
 
     @Bean
     public S3Client s3Client() {

--- a/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
+++ b/src/main/java/konkuk/chacall/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
             "/v3/api-docs/**","/oauth2/authorization/**",
             "/login/oauth2/code/**", "/actuator/health",
             "/auth/users", "/auth/token",
+            "/test/token",  // for test
 
             "/index.html", "/static/**" // for test
     };

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #35 

## 📝작업 내용

**이미지 업로드 흐름**
1. 이용자가 사진을 모두 업로드 후 확장자 파일만 body에 넣어서 `presigned URL 발급 api 호출`
2. 이미지 갯수 및 확장자 검증
3. 요청이 들어온 확장자 갯수만큼 presigned URL 발급
4. 반환받은 presigned URL을 통해 웹이 직접 s3에 이미지 업로드
5. 업로드된 이미지 url을 가지고 메뉴 등록 또는 푸드트럭 등록 api 호출

### 스크린샷 (선택)
<img width="1019" height="764" alt="스크린샷 2025-10-01 오후 5 35 55" src="https://github.com/user-attachments/assets/d7a17bcf-c08a-4b3b-b8d4-c071d7da6a69" />

## 💬리뷰 요구사항(선택)

같은 api를 가지고 파라미터로 구분할 수 있지만, 엔드포인트를 분리하는게 조금더 RESTful 하다고 판단해서 현재는 분리된채로 구현해둔 상황입니다. 이에 대해서 상균님 의견이 궁금합니다!

또, 한가지 더 고민이 되었던게 아직 저는 presigend URL을 통해 업로드 한 후 접근가능한 이미지 URL {cdn도메인 + 이미지 객체 key}을 파싱하지 않고 있는데, 이를 presigned URL을 발급하는 api에서 담당해서 presignedURL과 함께 세트로 반환해주는게 좋을까요? 아니면 푸드트럭 등록 또는 메뉴 등록 api 요청시에 key를 추출해서 내부적으로 파싱해서 테이블에 넣는게 좋을까요??

말이 좀 두서가 없는데 허헣 이해 안되시면 카톡 부탁쓰,,

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신기능**
  - 푸드트럭/메뉴 이미지용 사전 서명(Presigned) URL 발급 API 및 관련 엔드포인트/응답 DTO 추가 (URL 만료 10분)
- **오류 처리**
  - 이미지 개수(최대 9) 및 허용 확장자(png,jpg,jpeg,svg,webp,pdf) 검증 및 전용 에러 코드 추가
- **문서화**
  - 신규 이미지 API 및 관련 응답/오류 스웨거 문서 업데이트
- **잡무**
  - 개발 환경 JPA DDL을 create→update로 변경, S3 설정/버킷 구성 갱신
- **보안/동작**
  - 인증 필터 예외 흐름 개선 및 /test/token 경로 화이트리스트 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->