### PR TITLE
[FEAT] 푸드트럭 메뉴 조회 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -2,9 +2,12 @@ package konkuk.chacall.domain.foodtruck.application;
 
 import konkuk.chacall.domain.foodtruck.application.image.FoodTruckImageService;
 import konkuk.chacall.domain.foodtruck.application.command.FoodTruckCommandService;
+import konkuk.chacall.domain.foodtruck.application.menu.FoodTruckMenuService;
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckMenuRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckNameDuplicateCheckRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.ImageRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckMenuResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckNameDuplicateCheckResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
@@ -22,7 +25,9 @@ import org.springframework.transaction.annotation.Transactional;
 public class FoodTruckService {
 
     private final FoodTruckCommandService foodTruckCommandService;
+    private final FoodTruckMenuService foodTruckMenuService;
     private final FoodTruckImageService foodTruckImageService;
+
 
     private final MemberValidator memberValidator;
     private final OwnerValidator ownerValidator;
@@ -40,6 +45,12 @@ public class FoodTruckService {
                 foodTruckCommandService.isNameDuplicated(request.name()));
     }
 
+    public CursorPagingResponse<FoodTruckMenuResponse> getFoodTruckMenus(Long memberId, Long foodTruckId, FoodTruckMenuRequest request) {
+        memberValidator.validateAndGetMember(memberId);
+
+        return foodTruckMenuService.getFoodTruckMenus(foodTruckId, request);
+    }
+
     public ImageResponse createFoodTruckImagePresignedUrl(ImageRequest request, Long ownerId) {
         User owner = ownerValidator.validateAndGetOwner(ownerId);
 
@@ -51,6 +62,8 @@ public class FoodTruckService {
 
         return foodTruckImageService.createMenuImagePresignedUrl(request, owner);
     }
+
+
 
 
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -35,7 +35,7 @@ public class FoodTruckService {
     public CursorPagingResponse<FoodTruckResponse> getFoodTrucks(Long memberId, FoodTruckSearchRequest request) {
         memberValidator.validateAndGetMember(memberId);
 
-        return foodTruckCommandService.getFoodTrucks(request);
+        return foodTruckCommandService.getFoodTrucks(memberId, request);
     }
 
     public FoodTruckNameDuplicateCheckResponse isNameDuplicated(Long ownerId, FoodTruckNameDuplicateCheckRequest request) {

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/command/FoodTruckCommandService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/command/FoodTruckCommandService.java
@@ -4,24 +4,37 @@ import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
+import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
 public class FoodTruckCommandService {
 
     private final FoodTruckRepository foodTruckRepository;
+    private final SavedFoodTruckRepository savedFoodTruckRepository;
 
-    public CursorPagingResponse<FoodTruckResponse> getFoodTrucks(FoodTruckSearchRequest request) {
+    public CursorPagingResponse<FoodTruckResponse> getFoodTrucks(Long memberId, FoodTruckSearchRequest request) {
 
         Slice<FoodTruck> foodTruckSlice = foodTruckRepository.getFoodTrucks(request);
-        List<FoodTruckResponse> foodTrucks = foodTruckSlice.getContent().stream()
-                .map(FoodTruckResponse::of)
+        List<FoodTruck> content = foodTruckSlice.getContent();
+
+        // 이 페이지의 트럭 ID 목록
+        List<Long> foodTruckIds = content.stream()
+                .map(FoodTruck::getFoodTruckId)
+                .toList();
+
+        Set<Long> savedFoodTruckIds = foodTruckIds.isEmpty() ? Set.of() : savedFoodTruckRepository.findSavedTruckIdsIn(memberId, foodTruckIds);
+
+        List<FoodTruckResponse> foodTrucks = content.stream()
+                .map(ft -> FoodTruckResponse.of(ft, savedFoodTruckIds.contains(ft.getFoodTruckId())))
                 .toList();
 
         return CursorPagingResponse.of(

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
@@ -11,6 +11,7 @@ import konkuk.chacall.global.common.dto.CursorPagingRequest;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.dto.SortType;
 import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -24,12 +25,17 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FoodTruckMenuService {
 
+    private final FoodTruckRepository foodTruckRepository;
     private final MenuRepository menuRepository;
 
     public CursorPagingResponse<FoodTruckMenuResponse> getFoodTruckMenus(Long foodTruckId, FoodTruckMenuRequest request) {
         SortType sort = SortType.fromNullable(request.sort());
         CursorPagingRequest pagingRequest = request.pagingOrDefault(sort);
         Pageable pageable = PageRequest.of(0, pagingRequest.size());
+
+        if(!foodTruckRepository.existsById(foodTruckId)) {
+            throw new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND);
+        }
 
         Slice<Menu> menuSlice = switch (sort) {
             case NEWEST -> menuRepository.findVisibleMenusDesc(foodTruckId, pagingRequest.cursor(), pageable);

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
@@ -1,0 +1,45 @@
+package konkuk.chacall.domain.foodtruck.application.menu;
+
+import konkuk.chacall.domain.foodtruck.domain.model.Menu;
+import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
+import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckMenuRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckMenuResponse;
+import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
+import konkuk.chacall.global.common.dto.CursorPagingRequest;
+import konkuk.chacall.global.common.dto.CursorPagingResponse;
+import konkuk.chacall.global.common.dto.SortType;
+import konkuk.chacall.global.common.exception.BusinessException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FoodTruckMenuService {
+
+    private final MenuRepository menuRepository;
+
+    public CursorPagingResponse<FoodTruckMenuResponse> getFoodTruckMenus(Long foodTruckId, FoodTruckMenuRequest request) {
+        SortType sort = SortType.fromNullable(request.sort());
+        CursorPagingRequest pagingRequest = request.pagingOrDefault(sort);
+        Pageable pageable = PageRequest.of(0, pagingRequest.size());
+
+        Slice<Menu> menuSlice = switch (sort) {
+            case NEWEST -> menuRepository.findVisibleMenusDesc(foodTruckId, pagingRequest.cursor(), pageable);
+            case OLDEST -> menuRepository.findVisibleMenusAsc(foodTruckId, pagingRequest.cursor(), pageable);
+        };
+
+        List<FoodTruckMenuResponse> content = menuSlice.getContent().stream()
+                .map(FoodTruckMenuResponse::from)
+                .toList();
+
+        return CursorPagingResponse.of(content, FoodTruckMenuResponse::menuId, menuSlice.hasNext());
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
@@ -1,6 +1,7 @@
 package konkuk.chacall.domain.foodtruck.domain.repository;
 
 import konkuk.chacall.domain.foodtruck.domain.model.Menu;
+import konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,32 +18,56 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
     void deleteAllByFoodTruckId(@Param("foodTruckId") Long foodTruckId);
 
     @Query("""
-        select m
-        from Menu m
-        where m.foodTruck.foodTruckId = :foodTruckId
-          and m.menuId < :lastCursor
-        order by m.menuId desc
-        """)
+            select m
+            from Menu m
+            where m.foodTruck.foodTruckId = :foodTruckId
+              and m.menuId < :lastCursor
+            order by m.menuId desc
+            """)
     Slice<Menu> findMenusDesc(@Param("foodTruckId") Long foodTruckId,
                               @Param("lastCursor") Long lastCursor,
                               Pageable pageable);
 
     @Query("""
-        select m
-        from Menu m
-        where m.foodTruck.foodTruckId = :foodTruckId
-          and m.menuId > :lastCursor
-        order by m.menuId asc
-        """)
+            select m
+            from Menu m
+            where m.foodTruck.foodTruckId = :foodTruckId
+              and m.menuId > :lastCursor
+            order by m.menuId asc
+            """)
     Slice<Menu> findMenusAsc(@Param("foodTruckId") Long foodTruckId,
-                              @Param("lastCursor") Long lastCursor,
-                              Pageable pageable);
+                             @Param("lastCursor") Long lastCursor,
+                             Pageable pageable);
 
     @Query("""
-        select m from Menu m
-        where m.menuId = :menuId
-          and m.foodTruck.foodTruckId = :foodTruckId
-    """)
+            select m
+            from Menu m
+            where m.foodTruck.foodTruckId = :foodTruckId
+              and m.menuViewedStatus = konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus.ON
+              and m.menuId < :lastCursor
+            order by m.menuId desc
+            """)
+    Slice<Menu> findVisibleMenusDesc(@Param("foodTruckId") Long foodTruckId,
+                                     @Param("lastCursor") Long lastCursor,
+                                     Pageable pageable);
+
+    @Query("""
+            select m
+            from Menu m
+            where m.foodTruck.foodTruckId = :foodTruckId
+              and m.menuViewedStatus = konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus.ON
+              and m.menuId > :lastCursor
+            order by m.menuId asc
+            """)
+    Slice<Menu> findVisibleMenusAsc(@Param("foodTruckId") Long foodTruckId,
+                                                 @Param("lastCursor") Long lastCursor,
+                                                 Pageable pageable);
+
+    @Query("""
+                select m from Menu m
+                where m.menuId = :menuId
+                  and m.foodTruck.foodTruckId = :foodTruckId
+            """)
     Optional<Menu> findByMenuIdAndFoodTruckId(@Param("menuId") Long menuId,
                                               @Param("foodTruckId") Long foodTruckId);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
@@ -38,13 +38,6 @@ public class FoodTruckSearchRepositoryImpl implements FoodTruckSearchRepository{
     public Slice<FoodTruck> getFoodTrucks(FoodTruckSearchRequest request) {
         BooleanBuilder where = new BooleanBuilder();
 
-        // 검색어
-        if(request.keyword() != null && !request.keyword().isBlank()) {
-            String keyword = "%" + request.keyword().toLowerCase()+ "%";
-            where.and(foodTruck.name.lower().like(keyword)
-                    .or(foodTruck.description.lower().like(keyword)));
-        }
-
         // 지역 - prefix
         if (request.regionCodes() != null && !request.regionCodes().isEmpty()) {
             BooleanBuilder anyPrefix = new BooleanBuilder();

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -6,11 +6,15 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import konkuk.chacall.domain.foodtruck.application.FoodTruckService;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.ImageRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckMenuRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckNameDuplicateCheckRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckMenuResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckNameDuplicateCheckResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.ImageResponse;
+import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuRequest;
+import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
 import konkuk.chacall.global.common.dto.BaseResponse;
@@ -83,4 +87,17 @@ public class FoodTruckController {
         return BaseResponse.ok(foodTruckService.createMenuImagePresignedUrl(request, ownerId));
     }
 
+
+    @Operation(
+            summary = "푸드트럭 메뉴 목록 조회",
+            description = "푸드트럭 메뉴 목록을 조회합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_MENUS)
+    @GetMapping("/{foodTruckId}/menus")
+    public BaseResponse<CursorPagingResponse<FoodTruckMenuResponse>> getFoodTruckMenus (
+            @PathVariable final Long foodTruckId,
+            @ParameterObject final FoodTruckMenuRequest request,
+            @Parameter(hidden = true) @UserId final Long memberId) {
+        return BaseResponse.ok(foodTruckService.getFoodTruckMenus(memberId, foodTruckId, request));
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckMenuListRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckMenuListRequest.java
@@ -1,0 +1,27 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import konkuk.chacall.global.common.dto.CursorPagingRequest;
+import konkuk.chacall.global.common.dto.HasPaging;
+import konkuk.chacall.global.common.dto.SortType;
+
+@Schema(description = "메뉴 목록 조회 요청")
+public record FoodTruckMenuListRequest (
+        @Parameter(
+                description = "정렬 기준",
+                example = "최신순",
+                required = false,
+                allowEmptyValue = true,
+                schema = @Schema(
+                        type = "string",
+                        allowableValues = {"최신순", "오래된순"},
+                        defaultValue = "최신순"
+                )
+        )
+        SortType sort,
+
+        @Valid
+        CursorPagingRequest cursorPagingRequest
+) implements HasPaging {}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckMenuRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckMenuRequest.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.owner.presentation.dto.request;
+package konkuk.chacall.domain.foodtruck.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,7 +8,7 @@ import konkuk.chacall.global.common.dto.HasPaging;
 import konkuk.chacall.global.common.dto.SortType;
 
 @Schema(description = "메뉴 목록 조회 요청")
-public record MyFoodTruckMenuListRequest(
+public record FoodTruckMenuRequest(
         @Parameter(
                 description = "정렬 기준",
                 example = "최신순",
@@ -25,4 +25,3 @@ public record MyFoodTruckMenuListRequest(
         @Valid
         CursorPagingRequest cursorPagingRequest
 ) implements HasPaging {}
-

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckSearchRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckSearchRequest.java
@@ -15,10 +15,6 @@ import java.util.List;
 
 @Schema(description = "푸드트럭 검색/필터 요청")
 public record FoodTruckSearchRequest(
-
-        @Schema(description = "검색어(이름/설명 LIKE)", example = "디저트")
-        String keyword,
-
         @Parameter(
                 name = "regionCodes", in = ParameterIn.QUERY,
                 description = "지역 코드들 (prefix 검색, 여러 개 OR). 콤마로 구분",

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckMenuResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckMenuResponse.java
@@ -1,0 +1,29 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.chacall.domain.foodtruck.domain.model.Menu;
+
+@Schema(description = "메뉴 응답")
+public record FoodTruckMenuResponse (
+        @Schema(description = "메뉴 ID", example = "101")
+        Long menuId,
+        @Schema(description = "메뉴명", example = "크림파스타")
+        String name,
+        @Schema(description = "가격", example = "12000원")
+        String price,
+        @Schema(description = "설명", example = "진한 크림소스와 베이컨")
+        String description,
+        @Schema(description = "이미지 URL", example = "https://cdn.example.com/menus/101.jpg")
+        String imageUrl
+) {
+    public static FoodTruckMenuResponse from(Menu menu) {
+
+        return new FoodTruckMenuResponse(
+                menu.getMenuId(),
+                menu.getName(),
+                menu.parsingMenuPrice(),
+                menu.getDescription(),
+                menu.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckResponse.java
@@ -15,16 +15,20 @@ public record FoodTruckResponse(
         @Schema(description = "푸드트럭 평균 평점", example = "4.5")
         Double averageRating,
         @Schema(description = "푸드트럭 평점 수", example = "100")
-        Integer ratingCount
+        Integer ratingCount,
+        @Schema(description = "현재 사용자가 저장한 푸드트럭인지 여부", example = "true")
+        Boolean isSaved
+
 ) {
-    public static FoodTruckResponse of(FoodTruck foodTruck) {
+    public static FoodTruckResponse of(FoodTruck foodTruck, boolean isSaved) {
         return new FoodTruckResponse(
                 foodTruck.getFoodTruckId(),
                 foodTruck.getName(),
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(), // 대표 사진 (첫 번째 사진)
                 foodTruck.getDescription(),
                 foodTruck.getRatingInfo().getAverageRating(),
-                foodTruck.getRatingInfo().getRatingCount()
+                foodTruck.getRatingInfo().getRatingCount(),
+                isSaved
         );
     }
 }

--- a/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
@@ -11,7 +11,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, Long> {
 
@@ -32,4 +34,14 @@ public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, 
     @Modifying
     @Query("DELETE FROM SavedFoodTruck sft WHERE sft.foodTruck.foodTruckId = :foodTruckId")
     void deleteAllByFoodTruckId(@Param("foodTruckId") Long foodTruckId);
+
+    @Query("""
+                select s.foodTruck.foodTruckId
+                  from SavedFoodTruck s
+                 where s.member.userId = :userId
+                   and s.foodTruck.foodTruckId in :foodTruckIds
+            """)
+    Set<Long> findSavedTruckIdsIn(@Param("userId") Long userId,
+                                  @Param("foodTruckIds") List<Long> foodTruckIds);
+
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -1,7 +1,7 @@
 package konkuk.chacall.domain.owner.application;
 
 import konkuk.chacall.domain.owner.application.myfoodtruckmenu.MyFoodTruckMenuService;
-import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuListRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
 import konkuk.chacall.domain.owner.application.bankaccount.BankAccountService;
 import konkuk.chacall.domain.owner.application.chattemplate.ChatTemplateService;
@@ -138,7 +138,7 @@ public class OwnerService {
         myFoodTruckService.deleteMyFoodTruck(ownerId, foodTruckId);
     }
 
-    public CursorPagingResponse<MyFoodTruckMenuResponse> getMyFoodTruckMenus(Long ownerId, Long foodTruckId, MyFoodTruckMenuListRequest request) {
+    public CursorPagingResponse<MyFoodTruckMenuResponse> getMyFoodTruckMenus(Long ownerId, Long foodTruckId, MyFoodTruckMenuRequest request) {
         // 사장님인지 먼저 검증
         ownerValidator.validateAndGetOwner(ownerId);
 

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
@@ -5,8 +5,7 @@ import konkuk.chacall.domain.foodtruck.domain.model.Menu;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
-import konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus;
-import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuListRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterMenuRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateMenuStatusRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
@@ -30,7 +29,7 @@ public class MyFoodTruckMenuService {
     private final FoodTruckRepository foodTruckRepository;
     private final MenuRepository menuRepository;
 
-    public CursorPagingResponse<MyFoodTruckMenuResponse> getMyFoodTruckMenus(Long ownerId, Long foodTruckId, MyFoodTruckMenuListRequest request) {
+    public CursorPagingResponse<MyFoodTruckMenuResponse> getMyFoodTruckMenus(Long ownerId, Long foodTruckId, MyFoodTruckMenuRequest request) {
         SortType sort = SortType.fromNullable(request.sort());
         CursorPagingRequest pagingRequest = request.pagingOrDefault(sort);
         Pageable pageable = PageRequest.of(0, pagingRequest.size());

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -204,7 +204,7 @@ public class OwnerController {
     @GetMapping("/me/food-trucks/{foodTruckId}/menus")
     public BaseResponse<CursorPagingResponse<MyFoodTruckMenuResponse>> getMenus (
             @PathVariable final Long foodTruckId,
-            @ParameterObject final MyFoodTruckMenuListRequest request,
+            @ParameterObject final MyFoodTruckMenuRequest request,
             @Parameter(hidden = true) @UserId final Long ownerId) {
         return BaseResponse.ok(ownerService.getMyFoodTruckMenus(ownerId, foodTruckId, request));
     }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/MyFoodTruckMenuRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/MyFoodTruckMenuRequest.java
@@ -1,4 +1,4 @@
-package konkuk.chacall.domain.foodtruck.presentation.dto.request;
+package konkuk.chacall.domain.owner.presentation.dto.request;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -8,7 +8,7 @@ import konkuk.chacall.global.common.dto.HasPaging;
 import konkuk.chacall.global.common.dto.SortType;
 
 @Schema(description = "메뉴 목록 조회 요청")
-public record FoodTruckMenuListRequest (
+public record MyFoodTruckMenuRequest(
         @Parameter(
                 description = "정렬 기준",
                 example = "최신순",
@@ -25,3 +25,4 @@ public record FoodTruckMenuListRequest (
         @Valid
         CursorPagingRequest cursorPagingRequest
 ) implements HasPaging {}
+

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/ApproveFoodTruckStatusRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/ApproveFoodTruckStatusRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 
 public record ApproveFoodTruckStatusRequest(
-        @Schema(description = "변경할 푸드트럭 승인 상태", example = "ON")
+        @Schema(description = "변경할 푸드트럭 승인 상태", example = "OFF")
         @NotNull(message = "승인 상태는 필수입니다.")
         FoodTruckStatus status
 ) {}

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -195,7 +195,8 @@ public enum SwaggerResponseDescription {
     ))),
     GET_FOOD_TRUCK_MENUS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
-            USER_FORBIDDEN
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_FOUND
     ))),
 
     // Default

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -193,6 +193,10 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             INVALID_FILE_EXTENSION
     ))),
+    GET_FOOD_TRUCK_MENUS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #36 

## 📝작업 내용

푸드트럭 메뉴 조회 API 를 구현하였습니다.

사장님 - 나의 푸드트럭 메뉴 조회 API 와 로직이 사실상 동일해서 별 이슈는 없었습니다.
다만 한 가지 고려해야할 점이 있었는데, 사장님이 만약 메뉴들을 비공개 처리해두었다면, 해당 메뉴들은 다른 고객, 혹은 사용자들에게 보여져서는 안됩니다.
따라서 MenuViewedStatus 를 기반으로 'ON' (표시) 상태인 메뉴들만 화면에 보여질 수 있도록 구현하였습니다.

<img width="650" height="437" alt="스크린샷 2025-10-02 오후 11 17 47" src="https://github.com/user-attachments/assets/b9e0d172-d091-4938-a4d4-075b437e741c" />
<img width="915" height="193" alt="스크린샷 2025-10-02 오후 11 18 02" src="https://github.com/user-attachments/assets/98c211c6-5726-463b-85ba-21094c38d61f" />

위 예시는 2번 푸드트럭의 메뉴를 조회한 상황인데, 현재 DB의 데이터를 확인해보면, 2번 푸드트럭에 대해서 menuId = 7 (하와이안 피자) 가 존재하는 것을 볼 수 있습니다.
하지만 menuViewedStatus 가 'OFF' 로 설정되어있어서, 실제 조회시에는 해당 데이터가 조회되지 않는 모습을 확인할 수 있습니다.

워낙 간단해서 가볍게 훑고만 넘어가도 될 것 같슴다

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 푸드트럭 메뉴 목록 조회 API 추가: GET /{foodTruckId}/menus (커서 페이징, 정렬: 최신/오래된). 메뉴 ID·이름·가격·설명·이미지 제공.
  - 푸드트럭 목록에 '저장됨(isSaved)' 표기 추가.
- 문서
  - 메뉴 조회 요청/응답 및 오류(USER_NOT_FOUND, USER_FORBIDDEN, FOOD_TRUCK_NOT_FOUND) Swagger 반영.
- 변경
  - 검색 키워드 필터 제거로 검색 요청 파라미터 축소(키워드 필드 삭제).
  - 승인 상태 예시 값 수정(ON → OFF).
- 작업
  - 사장님용 메뉴 조회 DTO 명칭 정리 및 저장된 푸드트럭 조회 지원 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->