### PR TITLE
[FIX] 푸드트럭 조회시 푸드트럭의 음식 카테고리도 반환하도록 수정

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/MenuCategory.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/MenuCategory.java
@@ -7,13 +7,18 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MenuCategory implements EnumValue {
-    KOREAN("한식"),
-    CHINESE("중식"),
-    JAPANESE("일식"),
-    WESTERN("양식"),
+    MEAL("식사"),
+    LUNCHBOX("도시락"),
+    FUSION("퓨전식"),
     SNACK("분식"),
-    CAFE_DESSERT("카페/디저트"),
-    ETC("기타");
+    WESTERN("양식"),
+    CHINESE("중식"),
+    KOREAN("한식"),
+    LIGHT_MEAL("간식"),
+    DESSERT("디저트"),
+    BEVERAGE("음료"),
+    COFFEE("커피"),
+    UNDECIDED("미정");
 
     private final String value;
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/MenuCategoryList.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/MenuCategoryList.java
@@ -19,6 +19,13 @@ public class MenuCategoryList {
         return Collections.unmodifiableList(categories);
     }
 
+    public List<String> getMenuCategoryLabelList() {
+        return categories.stream()
+                .map(MenuCategory::getValue)
+                .toList();
+    }
+
+
     public boolean contains(MenuCategory category) {
         return categories != null && categories.contains(category);
     }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckSearchRequest.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/request/FoodTruckSearchRequest.java
@@ -48,7 +48,7 @@ public record FoodTruckSearchRequest(
 
         @Parameter(
                 name = "categories", in = ParameterIn.QUERY,
-                description = "음식 종류(여러 개 OR, CSV). 예) 분식,한식  / 허용값: 한식, 중식, 일식, 양식, 분식, 카페/디저트, 기타",
+                description = "음식 종류(여러 개 OR, CSV). 예) 분식,한식  / 허용값: 식사,도시락,퓨전식,분식,양식,중식,한식,간식,디저트,음료,커피,미정",
                 schema = @Schema(type = "string", example = "분식,한식")
         )
         List<MenuCategory> categories,

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckResponse.java
@@ -3,6 +3,8 @@ package konkuk.chacall.domain.foodtruck.presentation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
 
+import java.util.List;
+
 public record FoodTruckResponse(
         @Schema(description = "푸드트럭 식별자", example = "1")
         Long foodTruckId,
@@ -12,6 +14,8 @@ public record FoodTruckResponse(
         String photoUrl,
         @Schema(description = "푸드트럭 설명", example = "맛있는 푸드트럭입니다.")
         String description,
+        @Schema(description = "푸드트럭 음식 카테고리 (라벨 리스트)", example = "[\"한식\",\"분식\"]")
+        List<String> menuCategories,
         @Schema(description = "푸드트럭 평균 평점", example = "4.5")
         Double averageRating,
         @Schema(description = "푸드트럭 평점 수", example = "100")
@@ -26,6 +30,7 @@ public record FoodTruckResponse(
                 foodTruck.getName(),
                 foodTruck.getFoodTruckPhotoList().getMainPhotoUrl(), // 대표 사진 (첫 번째 사진)
                 foodTruck.getDescription(),
+                foodTruck.getMenuCategoryList().getMenuCategoryLabelList(),
                 foodTruck.getRatingInfo().getAverageRating(),
                 foodTruck.getRatingInfo().getRatingCount(),
                 isSaved


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #39 

## 📝작업 내용

푸드트럭 조회 시 푸드트럭의 메뉴 카테고리도 반환할 수 있도록 수정하였습니다.

프론트로부터 푸드트럭 조회 시, 해당 푸드트럭의 메뉴 카테고리를 문자열 배열 형식으로 반환해달라는 요구사항이 들어와서 기능을 추가하였습니다.

딱히 이슈는 없었습니다.

### 스크린샷
<img width="459" height="389" alt="스크린샷 2025-10-09 오전 12 53 23" src="https://github.com/user-attachments/assets/6cde20a6-26c2-45a0-90e3-fbe6d2735a49" />


## 💬리뷰 요구사항(선택)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 푸드트럭 조회 응답에 메뉴 카테고리 목록(List<String>)이 추가되어, 사용자가 메뉴 분류 라벨을 직접 확인할 수 있습니다.
  - 메뉴 카테고리 체계가 확장/개편되었습니다(예: 식사, 도시락, 퓨전식, 간식, 디저트, 음료, 커피, 미정 등). 기존 분식 유지.
- 문서
  - 검색 요청의 카테고리 허용값 설명을 최신 카테고리 체계에 맞게 업데이트했습니다(여러 개 OR, CSV 형식 안내 포함).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->