### PR TITLE
[FEAT] 푸드트럭 메뉴 수정/삭제 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/Menu.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/Menu.java
@@ -53,6 +53,13 @@ public class Menu extends BaseEntity {
                 .build();
     }
 
+    public void updateMenu(String name, Integer price, String description, String imageUrl) {
+        this.name = name;
+        this.price = price;
+        this.description = description;
+        this.imageUrl = imageUrl;
+    }
+
     public String parsingMenuPrice() {
         return price + "원";
     }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -169,7 +169,16 @@ public class OwnerService {
         // 사장님인지 먼저 검증
         ownerValidator.validateAndGetOwner(ownerId);
 
-        // 사장님 - 나의 푸드트럭 메뉴 상태 변경
+        // 사장님 - 나의 푸드트럭 메뉴 수정
         myFoodTruckMenuService.updateMenu(ownerId, foodTruckId, menuId, request);
+    }
+
+    @Transactional
+    public void deleteMenu(Long ownerId, Long foodTruckId, Long menuId) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 사장님 - 나의 푸드트럭 메뉴 삭제
+        myFoodTruckMenuService.deleteMenu(ownerId, foodTruckId, menuId);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -163,4 +163,13 @@ public class OwnerService {
         // 사장님 - 나의 푸드트럭 메뉴 상태 변경
         myFoodTruckMenuService.updateMenuStatus(ownerId, foodTruckId, menuId, request);
     }
+
+    @Transactional
+    public void updateMenu(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuRequest request) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 사장님 - 나의 푸드트럭 메뉴 상태 변경
+        myFoodTruckMenuService.updateMenu(ownerId, foodTruckId, menuId, request);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
@@ -7,6 +7,7 @@ import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import konkuk.chacall.domain.owner.presentation.dto.request.MyFoodTruckMenuRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.RegisterMenuRequest;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateMenuRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateMenuStatusRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
 import konkuk.chacall.global.common.dto.CursorPagingRequest;
@@ -81,5 +82,19 @@ public class MyFoodTruckMenuService {
 
         // 메뉴 표시 여부 변경 및 상태 전이 검증
         menu.changeViewedStatus(request.status());
+    }
+
+    public void updateMenu(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuRequest request) {
+
+        // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))) {
+            throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
+        }
+
+        // 메뉴 존재 여부 확인
+        Menu menu = menuRepository.findByMenuIdAndFoodTruckId(menuId, foodTruckId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.MENU_NOT_FOUND));
+
+        menu.updateMenu(request.name(), request.price(), request.description(), request.photoUrl());
     }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -239,4 +239,20 @@ public class OwnerController {
         ownerService.updateMenuStatus(ownerId, foodTruckId, menuId, request);
         return BaseResponse.ok(null);
     }
+
+    @Operation(
+            summary = "나의 푸드트럭 메뉴 수정",
+            description = "사장님 - 푸드트럭 메뉴를 수정합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_FOOD_TRUCK_MENU)
+    @PutMapping("/me/food-trucks/{foodTruckId}/menus/{menuId}")
+    public BaseResponse<Void> updateMenu(
+            @PathVariable final Long foodTruckId,
+            @PathVariable final Long menuId,
+            @Valid @RequestBody final UpdateMenuRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        ownerService.updateMenu(ownerId, foodTruckId, menuId, request);
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -255,4 +255,19 @@ public class OwnerController {
         ownerService.updateMenu(ownerId, foodTruckId, menuId, request);
         return BaseResponse.ok(null);
     }
+
+    @Operation(
+            summary = "나의 푸드트럭 메뉴 삭제",
+            description = "사장님 - 푸드트럭 메뉴를 삭제합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_DELETE_FOOD_TRUCK_MENU)
+    @DeleteMapping("/me/food-trucks/{foodTruckId}/menus/{menuId}")
+    public BaseResponse<Void> deleteMenu(
+            @PathVariable final Long foodTruckId,
+            @PathVariable final Long menuId,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        ownerService.deleteMenu(ownerId, foodTruckId, menuId);
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateMenuRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateMenuRequest.java
@@ -1,0 +1,30 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.Size;
+
+public record UpdateMenuRequest(
+
+        @Schema(description = "메뉴 이름", example = "불고기버거")
+        @NotBlank(message = "메뉴 이름은 필수입니다.")
+        @Size(max = 18, message = "메뉴 이름은 최대 18자까지 입력 가능합니다.")
+        String name,
+
+        @Schema(description = "메뉴 설명", example = "신선한 채소와 불고기를 듬뿍 넣은 수제 버거")
+        @NotBlank(message = "메뉴 설명은 필수입니다.")
+        @Size(max = 50, message = "메뉴 설명은 최대 50자까지 입력 가능합니다.")
+        String description,
+
+        @Schema(description = "메뉴 가격 (원화 단위)", example = "7500")
+        @NotNull(message = "가격은 필수입니다.")
+        @Positive(message = "가격은 0보다 커야 합니다.")
+        Integer price,
+
+        @Schema(description = "대표 메뉴 이미지 URL", example = "https://cdn.example.com/menus/bulgogi-burger.jpg")
+        @NotBlank(message = "사진은 반드시 1장 등록해야 합니다.")
+        String photoUrl
+) {
+}

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -107,6 +107,12 @@ public enum SwaggerResponseDescription {
             MENU_NOT_FOUND,
             INVALID_MENU_STATUS_TRANSITION
     ))),
+    OWNER_UPDATE_FOOD_TRUCK_MENU(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_APPROVED,
+            MENU_NOT_FOUND
+    ))),
 
 
     // Member

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -113,6 +113,12 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_APPROVED,
             MENU_NOT_FOUND
     ))),
+    OWNER_DELETE_FOOD_TRUCK_MENU(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_APPROVED,
+            MENU_NOT_FOUND
+    ))),
 
 
     // Member


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #42 

## 📝작업 내용

푸드트럭 메뉴 수정/삭제 기능을 구현하였습니다.

푸드트럭 메뉴 수정의 경우, 푸드트럭 메뉴 등록과 같이 메뉴의 이름, 이미지 url, 가격, 설명 등을 입력받고 그것들을 기반으로 푸드트럭의 정보를 업데이트 하는 형식인 것으로 확인되었습니다.
따라서 Put 메서드를 사용하도록 구현하였습니다.

푸드트럭 메뉴 삭제의 경우 푸드트럭 메뉴가 삭제될 때 S3에 존재하는 메뉴의 이미지까지 삭제될 수 있도록 CdnUrlResolver, S3Service 를 주입하여 메뉴 삭제시 S3에서 이미지도 동시에 삭제되도록 구현하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 사장님 전용 메뉴 수정/삭제 엔드포인트 추가: PUT/DELETE /me/food-trucks/{foodTruckId}/menus/{menuId}
  * 메뉴의 이름, 설명, 가격, 사진 URL을 유효성 검증과 함께 업데이트 가능
* 문서화
  * Swagger에 메뉴 수정/삭제 API 및 오류 케이스(사용자 없음, 권한 없음, 미승인 푸드트럭, 메뉴 없음) 추가하여 가이드와 응답 예측 가능성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->