### PR TITLE
[FEAT] 푸드트럭 상태 변경 로직 추가

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -122,4 +122,12 @@ public class FoodTruck extends BaseEntity {
                 .map(serviceArea -> serviceArea.getRegion().getFullName())
                 .collect(Collectors.joining(", "));
     }
+
+    public void changeViewedStatus(FoodTruckViewedStatus targetViewedStatus) {
+        if(this.foodTruckViewedStatus == targetViewedStatus) {
+            throw new DomainRuleException(ErrorCode.INVALID_FOOD_TRUCK_STATUS_TRANSITION);
+        }
+
+        this.foodTruckViewedStatus = targetViewedStatus;
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -76,6 +76,11 @@ public class FoodTruck extends BaseEntity {
     @Column(nullable = false, length = 20)
     private FoodTruckStatus foodTruckStatus = FoodTruckStatus.PENDING;
 
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 3)
+    private FoodTruckViewedStatus foodTruckViewedStatus = FoodTruckViewedStatus.OFF;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
@@ -6,10 +6,7 @@ import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
-import konkuk.chacall.domain.foodtruck.domain.value.AvailableQuantity;
-import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
-import konkuk.chacall.domain.foodtruck.domain.value.MenuCategory;
-import konkuk.chacall.domain.foodtruck.domain.value.PaymentMethod;
+import konkuk.chacall.domain.foodtruck.domain.value.*;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.DateRangeRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
 import konkuk.chacall.global.common.dto.SortType;
@@ -107,6 +104,9 @@ public class FoodTruckSearchRepositoryImpl implements FoodTruckSearchRepository{
 
         // 푸드트럭 상태
         where.and(foodTruck.foodTruckStatus.eq(FoodTruckStatus.ON));
+
+        // 푸드트럭 노출 여부
+        where.and(foodTruck.foodTruckViewedStatus.eq(FoodTruckViewedStatus.ON));
 
         // 커서 기반 페이징
         var paging = request.pagingOrDefault(SortType.NEWEST);

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckViewedStatus.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckViewedStatus.java
@@ -1,0 +1,15 @@
+package konkuk.chacall.domain.foodtruck.domain.value;
+
+import lombok.Getter;
+
+@Getter
+public enum FoodTruckViewedStatus {
+    ON("표시"),
+    OFF("미표시");
+
+    private final String value;
+
+    FoodTruckViewedStatus(String value) {
+        this.value = value;
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
@@ -2,6 +2,7 @@ package konkuk.chacall.domain.member.application.foodtruck;
 
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckViewedStatus;
 import konkuk.chacall.domain.member.domain.SavedFoodTruck;
 import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
 import konkuk.chacall.domain.member.presentation.dto.request.UpdateFoodTruckSaveStatusRequest;
@@ -55,7 +56,7 @@ public class SavedFoodTruckService {
     public CursorPagingResponse<SavedFoodTruckResponse> getSavedFoodTrucks(CursorPagingRequest cursorPagingRequest, User member) {
         // 저장된 푸드트럭 목록 조회
         Slice<SavedFoodTruck> savedFoodTruckSlice = savedFoodTruckRepository
-                .findMemberSavedFoodTruckWithCursor(member, cursorPagingRequest.cursor(), PageRequest.of(0, cursorPagingRequest.size()));
+                .findMemberSavedFoodTruckWithCursor(member, FoodTruckViewedStatus.ON, cursorPagingRequest.cursor(), PageRequest.of(0, cursorPagingRequest.size()));
         List<SavedFoodTruck> savedFoodTrucks = savedFoodTruckSlice.getContent();
 
         // 응답 DTO로 변환

--- a/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
@@ -1,6 +1,7 @@
 package konkuk.chacall.domain.member.domain.repository;
 
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckViewedStatus;
 import konkuk.chacall.domain.member.domain.SavedFoodTruck;
 import konkuk.chacall.domain.user.domain.model.User;
 import org.springframework.data.domain.Pageable;
@@ -23,11 +24,14 @@ public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, 
 
     @EntityGraph(attributePaths = {"foodTruck"})
     @Query("SELECT sft FROM SavedFoodTruck sft " +
+            "JOIN sft.foodTruck ft " +
             "WHERE sft.member = :member " +
+            "AND ft.foodTruckViewedStatus = :status " +
             "AND sft.savedFoodTruckId < :lastCursor " +
             "ORDER BY sft.savedFoodTruckId DESC")
     Slice<SavedFoodTruck> findMemberSavedFoodTruckWithCursor(
             @Param("member") User member,
+            @Param("status") FoodTruckViewedStatus status,
             @Param("lastCursor") Long lastCursor,
             Pageable pageable);
 

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -138,6 +138,15 @@ public class OwnerService {
         myFoodTruckService.deleteMyFoodTruck(ownerId, foodTruckId);
     }
 
+    @Transactional
+    public void updateFoodTruckViewedStatus(Long ownerId, Long foodTruckId, UpdateFoodTruckViewedStatusRequest request) {
+        // 사장님인지 먼저 검증
+        ownerValidator.validateAndGetOwner(ownerId);
+
+        // 사장님 - 나의 푸드트럭 표시 상태 변경
+        myFoodTruckService.updateFoodTruckViewedStatus(ownerId, foodTruckId, request);
+    }
+
     public CursorPagingResponse<MyFoodTruckMenuResponse> getMyFoodTruckMenus(Long ownerId, Long foodTruckId, MyFoodTruckMenuRequest request) {
         // 사장님인지 먼저 검증
         ownerValidator.validateAndGetOwner(ownerId);

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
@@ -6,8 +6,10 @@ import konkuk.chacall.domain.foodtruck.domain.repository.AvailableDateRepository
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckServiceAreaRepository;
 import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import konkuk.chacall.domain.member.domain.repository.RatingRepository;
 import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
+import konkuk.chacall.domain.owner.presentation.dto.request.UpdateFoodTruckViewedStatusRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckResponse;
 import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
 import konkuk.chacall.global.common.dto.CursorPagingRequest;
@@ -99,6 +101,16 @@ public class MyFoodTruckService {
 
         return serviceAreas.stream()
                 .collect(Collectors.groupingBy(sa -> sa.getFoodTruck().getFoodTruckId()));
+    }
+
+    public void updateFoodTruckViewedStatus(Long ownerId, Long foodTruckId, UpdateFoodTruckViewedStatusRequest request) {
+
+        // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
+        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))
+                .orElseThrow(() -> new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED));
+
+        // 메뉴 표시 여부 변경 및 상태 전이 검증
+        foodTruck.changeViewedStatus(request.status());
     }
 
     private List<MyFoodTruckResponse> mapToMyFoodTruckResponse(List<FoodTruck> foodTrucks, Map<Long, List<FoodTruckServiceArea>> serviceAreaMap) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -197,6 +197,21 @@ public class OwnerController {
     }
 
     @Operation(
+            summary = "나의 푸드트럭 표시 상태 변경",
+            description = "사장님 - 푸드트럭의 표시 상태를 변경합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.OWNER_UPDATE_FOOD_TRUCK_VIEWED_STATUS)
+    @PatchMapping("/me/food-trucks/{foodTruckId}/change-status")
+    public BaseResponse<Void> updateFoodTruckViewedStatus(
+            @PathVariable final Long foodTruckId,
+            @Valid @RequestBody final UpdateFoodTruckViewedStatusRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        ownerService.updateFoodTruckViewedStatus(ownerId, foodTruckId, request);
+        return BaseResponse.ok(null);
+    }
+
+    @Operation(
             summary = "나의 푸드트럭 메뉴 목록 조회",
             description = "사장님 - 푸드트럭 메뉴 목록을 조회합니다."
     )

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateFoodTruckViewedStatusRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/UpdateFoodTruckViewedStatusRequest.java
@@ -1,0 +1,12 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckViewedStatus;
+
+public record UpdateFoodTruckViewedStatusRequest(
+        @Schema(description = "변경할 푸드트럭 표시 여부", example = "OFF")
+        @NotNull(message = "푸드트럭 표시 상태는 필수입니다.")
+        FoodTruckViewedStatus status
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
@@ -18,7 +18,9 @@ public record MyFoodTruckResponse(
         @Schema(description = "운영 가능 시간대", example = "09:00 ~ 21:00")
         String activeTime,
         @Schema(description = "호출 가능 지역", example = "서울 전체, 경기도 수원시 영통구, 인천 계양구")
-        String serviceArea
+        String serviceArea,
+        @Schema(description = "푸드트럭 표시 여부", example = "ON/OFF")
+        String status
 ) {
         /**
          * FoodTruck 엔티티와 연관된 FoodTruckServiceArea 리스트를 사용하여 DTO 를 생성
@@ -36,7 +38,8 @@ public record MyFoodTruckResponse(
                         foodTruck.getName(),
                         foodTruck.getDescription(),
                         foodTruck.getActiveTime(),
-                        foodTruck.getServiceAreas(serviceAreas)
+                        foodTruck.getServiceAreas(serviceAreas),
+                        foodTruck.getFoodTruckViewedStatus().name()
                 );
         }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/OwnerReservationDetailResponse.java
@@ -8,6 +8,8 @@ import konkuk.chacall.domain.user.domain.model.User;
 import java.util.List;
 
 public record OwnerReservationDetailResponse(
+        @Schema(description = "푸드트럭 이름", example = "차콜 푸드트럭")
+        String foodTruckName,
         @Schema(description = "상대방(손님)의 프로필 이미지 URL",
                 example = "https://image.url/path/profile.jpg")
         String profileImage,
@@ -28,8 +30,8 @@ public record OwnerReservationDetailResponse(
                 example = "핫도그, 국밥, 짜장면")
         String menu,
         @Schema(description = "지불된 예약금액",
-                example = "50000원")
-        String deposit,
+                example = "50000")
+        int deposit,
         @Schema(description = "전기 사용 가능 여부",
                 example = "가능")
         String electricityInfo,
@@ -46,6 +48,7 @@ public record OwnerReservationDetailResponse(
         // boolean 값을 화면에 표시할 문자열로 변환
 
         return new OwnerReservationDetailResponse(
+                reservation.getFoodTruck().getName(),
                 member.getProfileImageUrl(),
                 member.getName(),
                 reservation.getReservationInfo().getFullAddress(),
@@ -53,7 +56,7 @@ public record OwnerReservationDetailResponse(
                 reservation.getReservationStatus() == ReservationStatus.CANCELLED ?  // 예약 취소 상태이면 null 반환
                         null : reservation.getPdfUrl(),
                 reservation.getReservationInfo().getMenu(),
-                reservation.getReservationInfo().parsingReservationDeposit(),
+                reservation.getReservationInfo().getDeposit(),
                 reservation.getReservationInfo().parsingIsUserElectricity(),
                 reservation.getReservationInfo().getEtcRequest(),
                 reservation.getReservationStatus().getValue()

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -90,6 +90,12 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             FOOD_TRUCK_NOT_FOUND
     ))),
+    OWNER_UPDATE_FOOD_TRUCK_VIEWED_STATUS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_APPROVED,
+            INVALID_FOOD_TRUCK_STATUS_TRANSITION
+    ))),
     OWNER_GET_FOOD_TRUCK_MENUS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
             USER_FORBIDDEN,

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #44 

## 📝작업 내용

푸드트럭에 표시 여부 (= 노출 여부) 가 추가되었다고 하여 해당 기능을 구현하였습니다.

### 푸드트럭 조회 - 고객
푸드트럭 조회 시 푸드트럭 노출 여부가 ON 인 것들만 조회될 수 있도록 변경하였습니다.

### 일반 유저 - 저장된 푸드트럭 조회 
저장된 푸드트럭 조회 시에도 푸드트럭 노출 여부가 ON 인 것들만 조회될 수 있도록 하였습니다.

### 사장님 - 나의 푸드트럭 조회
나의 푸드트럭 조회시에는 노출여부에 관계 없이 모든 푸드트럭이 조회될 수 있도록 하였습니다.

### 푸드트럭 표시 상태 변경
기존에 메뉴 표시 상태 변경 API 와 사실상 거의 동일하게 구현하였습니다.

### 사장님 - 예약 내역 상세 조회
찬영님이 사장님 - 예약 내역 상세 조회에서 푸드트럭 이름 반환 & 예약금을 정수형으로 반환 이 두가지를 요구하셔서 해당 기능들도 추가적으로 구현하였습니다.


### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
foodTruckViewedStatus 라는 컬럼이 추가되다보니 더미데이터도 바꿔주어야할 것 같습니다. 우선 전부다 ON(표시) 상태로 바꿔둘게요


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 푸드트럭 표시 상태(ON/OFF) 추가 및 소유자 대상 표시 상태 변경 PATCH API 제공.
  * 내 푸드트럭, 저장한 푸드트럭, 검색 결과에서 표시 상태가 ON인 항목만 노출.
  * 내 푸드트럭 응답에 표시 상태 필드 추가.
  * 예약 상세 응답에 푸드트럭명 추가 및 보증금 타입을 정수로 변경.

* Documentation
  * Swagger에 표시 상태 업데이트 설명 및 관련 오류 코드/응답 예시 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->