### PR TITLE
[FEAT] 사장님 & 푸드트럭 최초 등록 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -37,7 +37,7 @@ public class FoodTruck extends BaseEntity {
 
     private String activeTime;
 
-    private boolean timeDiscussRequired;
+    private Boolean timeDiscussRequired;
 
     @Convert(converter = PhotoUrlListConverter.class)
     private PhotoUrlList foodTruckPhotoList;
@@ -88,7 +88,7 @@ public class FoodTruck extends BaseEntity {
                 .description(null)
                 .phoneNumber(null)
                 .activeTime(null)
-                .timeDiscussRequired(false)
+                .timeDiscussRequired(null)
                 .foodTruckPhotoList(null)
                 .menuCategoryList(null)
                 .availableQuantity(null)

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -120,13 +120,13 @@ public class FoodTruck extends BaseEntity {
     public void approveFoodTruck(FoodTruckStatus targetFoodTruckStatus) {
 
         // 운영자 - 승인 대기 -> 승인 OR 승인 거부
-        if (this.foodTruckStatus == FoodTruckStatus.PENDING && (targetFoodTruckStatus == FoodTruckStatus.ON || targetFoodTruckStatus == FoodTruckStatus.REJECTED)) {
+        if (this.foodTruckStatus == FoodTruckStatus.PENDING && (targetFoodTruckStatus == FoodTruckStatus.APPROVED || targetFoodTruckStatus == FoodTruckStatus.REJECTED)) {
             this.foodTruckStatus = targetFoodTruckStatus;
             return;
         }
 
         // 운영자 - 승인 거부 -> 승인
-        if (this.foodTruckStatus == FoodTruckStatus.REJECTED && targetFoodTruckStatus == FoodTruckStatus.ON) {
+        if (this.foodTruckStatus == FoodTruckStatus.REJECTED && targetFoodTruckStatus == FoodTruckStatus.APPROVED) {
             this.foodTruckStatus = targetFoodTruckStatus;
             return;
         }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -81,6 +81,28 @@ public class FoodTruck extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User owner;
 
+    public static FoodTruck createEmptyFoodTruck(User owner, String name) {
+        return FoodTruck.builder()
+                .owner(owner)
+                .name(name)
+                .description(null)
+                .phoneNumber(null)
+                .activeTime(null)
+                .timeDiscussRequired(false)
+                .foodTruckPhotoList(null)
+                .menuCategoryList(null)
+                .availableQuantity(null)
+                .needElectricity(null)
+                .paymentMethod(null)
+                .operatingInfo(null)
+                .option(null)
+                .rejectionReason(null)
+                .foodTruckStatus(FoodTruckStatus.PENDING)
+                .foodTruckViewedStatus(FoodTruckViewedStatus.OFF)
+                .ratingInfo(RatingInfo.createInitial())
+                .build();
+    }
+
     private boolean isOwnedBy(Long ownerId) {
         return this.owner.getUserId().equals(ownerId);
     }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -29,36 +29,29 @@ public class FoodTruck extends BaseEntity {
     @Column(nullable = false)
     private String name;
 
-    @Column(length = 300, nullable = false)
+    @Column(length = 300)
     private String description;
 
-    @Column(length = 15, nullable = false)
+    @Column(length = 15)
     private String phoneNumber;
 
-    @Column(nullable = false)
     private String activeTime;
 
-    @Column(nullable = false)
     private boolean timeDiscussRequired;
 
     @Convert(converter = PhotoUrlListConverter.class)
-    @Column(nullable = false)
     private PhotoUrlList foodTruckPhotoList;
 
     @Convert(converter = MenuCategoryListConverter.class)
-    @Column(nullable = false)
     private MenuCategoryList menuCategoryList;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private AvailableQuantity availableQuantity;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private NeedElectricity needElectricity;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private PaymentMethod paymentMethod;
 
     @Column(name = "operating_info", length = 800)
@@ -66,6 +59,9 @@ public class FoodTruck extends BaseEntity {
 
     @Column(name = "option", length = 800)
     private String option;
+
+    @Column(name = "rejection_reason", length = 30)
+    private String rejectionReason;
 
     @Builder.Default
     @Column(nullable = false)
@@ -102,13 +98,13 @@ public class FoodTruck extends BaseEntity {
     public void approveFoodTruck(FoodTruckStatus targetFoodTruckStatus) {
 
         // 운영자 - 승인 대기 -> 승인 OR 승인 거부
-        if (this.foodTruckStatus == FoodTruckStatus.PENDING && (targetFoodTruckStatus == FoodTruckStatus.OFF || targetFoodTruckStatus == FoodTruckStatus.REJECTED)) {
+        if (this.foodTruckStatus == FoodTruckStatus.PENDING && (targetFoodTruckStatus == FoodTruckStatus.ON || targetFoodTruckStatus == FoodTruckStatus.REJECTED)) {
             this.foodTruckStatus = targetFoodTruckStatus;
             return;
         }
 
         // 운영자 - 승인 거부 -> 승인
-        if (this.foodTruckStatus == FoodTruckStatus.REJECTED && targetFoodTruckStatus == FoodTruckStatus.OFF) {
+        if (this.foodTruckStatus == FoodTruckStatus.REJECTED && targetFoodTruckStatus == FoodTruckStatus.ON) {
             this.foodTruckStatus = targetFoodTruckStatus;
             return;
         }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruckDocument.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruckDocument.java
@@ -26,4 +26,12 @@ public class FoodTruckDocument {
 
     @Column(nullable = false, length = 500)
     private String documentUrl;
+
+    public static FoodTruckDocument create(FoodTruck foodTruck, DocumentType type, String documentUrl) {
+        return FoodTruckDocument.builder()
+                .foodTruck(foodTruck)
+                .type(type)
+                .documentUrl(documentUrl)
+                .build();
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruckDocument.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruckDocument.java
@@ -1,0 +1,29 @@
+package konkuk.chacall.domain.foodtruck.domain.model;
+
+import jakarta.persistence.*;
+import konkuk.chacall.domain.foodtruck.domain.value.DocumentType;
+import lombok.*;
+
+@Builder
+@Entity
+@Table(name = "food_truck_documents")
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class FoodTruckDocument {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "food_truck_document_id", nullable = false)
+    private Long foodTruckDocumentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "food_truck_id", nullable = false)
+    private FoodTruck foodTruck;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private DocumentType type;
+
+    @Column(nullable = false, length = 500)
+    private String documentUrl;
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
@@ -1,0 +1,2 @@
+package konkuk.chacall.domain.foodtruck.domain.repository;public interface FoodTruckDocumentRepository {
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
@@ -1,2 +1,7 @@
-package konkuk.chacall.domain.foodtruck.domain.repository;public interface FoodTruckDocumentRepository {
+package konkuk.chacall.domain.foodtruck.domain.repository;
+
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckDocument;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FoodTruckDocumentRepository extends JpaRepository<FoodTruckDocument, Long> {
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -25,7 +25,7 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
                 from FoodTruck f
                 where f.foodTruckId = :foodTruckId
                   and f.owner.userId = :ownerId
-                  and f.foodTruckStatus = :statuses
+                  and f.foodTruckStatus = :status
             """)
     Optional<FoodTruck> findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
             @Param("foodTruckId") Long foodTruckId,
@@ -37,7 +37,7 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
                 from FoodTruck f
                 where f.foodTruckId = :foodTruckId
                   and f.owner.userId = :ownerId
-                  and f.foodTruckStatus = :statuses
+                  and f.foodTruckStatus = :status
             """)
     boolean existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
             @Param("foodTruckId") Long foodTruckId,

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -25,24 +25,24 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
                 from FoodTruck f
                 where f.foodTruckId = :foodTruckId
                   and f.owner.userId = :ownerId
-                  and f.foodTruckStatus in :statuses
+                  and f.foodTruckStatus = :statuses
             """)
-    Optional<FoodTruck> findByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(
+    Optional<FoodTruck> findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
             @Param("foodTruckId") Long foodTruckId,
             @Param("ownerId") Long ownerId,
-            @Param("statuses") Collection<FoodTruckStatus> statuses);
+            @Param("status") FoodTruckStatus status);
 
     @Query("""
                 select (count(f) > 0)
                 from FoodTruck f
                 where f.foodTruckId = :foodTruckId
                   and f.owner.userId = :ownerId
-                  and f.foodTruckStatus in :statuses
+                  and f.foodTruckStatus = :statuses
             """)
-    boolean existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(
+    boolean existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
             @Param("foodTruckId") Long foodTruckId,
             @Param("ownerId") Long ownerId,
-            @Param("statuses") Collection<FoodTruckStatus> statuses
+            @Param("status") FoodTruckStatus status
     );
 
     boolean existsByName(String name);

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/infra/FoodTruckSearchRepositoryImpl.java
@@ -103,7 +103,7 @@ public class FoodTruckSearchRepositoryImpl implements FoodTruckSearchRepository{
         }
 
         // 푸드트럭 상태
-        where.and(foodTruck.foodTruckStatus.eq(FoodTruckStatus.ON));
+        where.and(foodTruck.foodTruckStatus.eq(FoodTruckStatus.APPROVED));
 
         // 푸드트럭 노출 여부
         where.and(foodTruck.foodTruckViewedStatus.eq(FoodTruckViewedStatus.ON));

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/DocumentType.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/DocumentType.java
@@ -1,0 +1,14 @@
+package konkuk.chacall.domain.foodtruck.domain.value;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DocumentType {
+
+    BUSINESS_LICENSE("사업자등록증"),
+    OTHER("기타 서류");
+
+    private final String value;
+}

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/DocumentType.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/DocumentType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum DocumentType {
 
-    BUSINESS_LICENSE("사업자등록증"),
+    BUSINESS_REGISTRATION("사업자등록증"),
     OTHER("기타 서류");
 
     private final String value;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
@@ -7,8 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FoodTruckStatus {
     PENDING("승인 대기"),       // 아직 관리자의 승인이 끝나지 않은 상태
-    ON("승인 완료 - 노출"),     // 승인 완료 + 사용자에게 보여지는 상태
-    OFF("승인 완료 - 비노출"),  // 승인 완료 + 사용자에게 보이지 않는 상태
+    ON("승인 완료"),
     REJECTED("승인 거부");     // 관리자가 승인을 거부한 상태
 
     private final String description;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FoodTruckStatus {
     PENDING("승인 대기"),       // 아직 관리자의 승인이 끝나지 않은 상태
-    ON("승인 완료"),
+    APPROVED("승인 완료"),
     REJECTED("승인 거부");     // 관리자가 승인을 거부한 상태
 
     private final String description;

--- a/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/OwnerService.java
@@ -191,4 +191,13 @@ public class OwnerService {
         // 사장님 - 나의 푸드트럭 메뉴 삭제
         myFoodTruckMenuService.deleteMenu(ownerId, foodTruckId, menuId);
     }
+
+    @Transactional
+    public void createNewFoodTruck(Long ownerId, FoodTruckCreateRequest request) {
+        // 사장님인지 먼저 검증
+        User owner = ownerValidator.validateAndGetOwner(ownerId);
+
+        // 푸드트럭 최초 등록
+        myFoodTruckService.createNewFoodTruck(owner, request);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
@@ -108,7 +108,7 @@ public class MyFoodTruckService {
     public void updateFoodTruckViewedStatus(Long ownerId, Long foodTruckId, UpdateFoodTruckViewedStatusRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)
+        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.APPROVED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED));
 
         // 메뉴 표시 여부 변경 및 상태 전이 검증

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
@@ -1,17 +1,18 @@
 package konkuk.chacall.domain.owner.application.myfoodtruck;
 
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckDocument;
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckServiceArea;
-import konkuk.chacall.domain.foodtruck.domain.repository.AvailableDateRepository;
-import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
-import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckServiceAreaRepository;
-import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
+import konkuk.chacall.domain.foodtruck.domain.repository.*;
+import konkuk.chacall.domain.foodtruck.domain.value.DocumentType;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import konkuk.chacall.domain.member.domain.repository.RatingRepository;
 import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
+import konkuk.chacall.domain.owner.presentation.dto.request.FoodTruckCreateRequest;
 import konkuk.chacall.domain.owner.presentation.dto.request.UpdateFoodTruckViewedStatusRequest;
 import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckResponse;
 import konkuk.chacall.domain.reservation.domain.repository.ReservationRepository;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingRequest;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.exception.BusinessException;
@@ -37,6 +38,7 @@ public class MyFoodTruckService {
     private final SavedFoodTruckRepository savedFoodTruckRepository;
     private final AvailableDateRepository availableDateRepository;
     private final RatingRepository ratingRepository;
+    private final FoodTruckDocumentRepository foodTruckDocumentRepository;
 
     public CursorPagingResponse<MyFoodTruckResponse> getMyFoodTrucks(CursorPagingRequest request, Long ownerId) {
         // 1. 커서 기반으로 푸드트럭 Slice 조회
@@ -111,6 +113,22 @@ public class MyFoodTruckService {
 
         // 메뉴 표시 여부 변경 및 상태 전이 검증
         foodTruck.changeViewedStatus(request.status());
+    }
+
+    public void createNewFoodTruck(User owner, FoodTruckCreateRequest request) {
+        // 1. 비어 있는 푸드트럭 엔티티 생성 (null 필드 초기화)
+        FoodTruck foodTruck = FoodTruck.createEmptyFoodTruck(owner, request.name());
+        foodTruckRepository.save(foodTruck);
+
+        // 2. 서류 등록 로직 (사업자등록증 + 기타 5장)
+        FoodTruckDocument business = FoodTruckDocument.create(foodTruck, DocumentType.BUSINESS_REGISTRATION, request.businessRegistrationUrl());
+        foodTruckDocumentRepository.save(business);
+
+        List<FoodTruckDocument> otherDocs = request.otherDocumentUrls().stream()
+                .map(url -> FoodTruckDocument.create(foodTruck, DocumentType.OTHER, url))
+                .toList();
+
+        foodTruckDocumentRepository.saveAll(otherDocs);
     }
 
     private List<MyFoodTruckResponse> mapToMyFoodTruckResponse(List<FoodTruck> foodTrucks, Map<Long, List<FoodTruckServiceArea>> serviceAreaMap) {

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruck/MyFoodTruckService.java
@@ -106,7 +106,7 @@ public class MyFoodTruckService {
     public void updateFoodTruckViewedStatus(Long ownerId, Long foodTruckId, UpdateFoodTruckViewedStatusRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))
+        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED));
 
         // 메뉴 표시 여부 변경 및 상태 전이 검증

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
@@ -41,7 +41,7 @@ public class MyFoodTruckMenuService {
         Pageable pageable = PageRequest.of(0, pagingRequest.size());
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.APPROVED)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -61,7 +61,7 @@ public class MyFoodTruckMenuService {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
         FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
-                        foodTruckId, ownerId, FoodTruckStatus.ON)
+                        foodTruckId, ownerId, FoodTruckStatus.APPROVED)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED));
 
         Menu menu = Menu.create(
@@ -77,7 +77,7 @@ public class MyFoodTruckMenuService {
     public void updateMenuStatus(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuStatusRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.APPROVED)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -92,7 +92,7 @@ public class MyFoodTruckMenuService {
     public void updateMenu(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.APPROVED)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -106,7 +106,7 @@ public class MyFoodTruckMenuService {
     public void deleteMenu(Long ownerId, Long foodTruckId, Long menuId) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.APPROVED)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 

--- a/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/owner/application/myfoodtruckmenu/MyFoodTruckMenuService.java
@@ -41,7 +41,7 @@ public class MyFoodTruckMenuService {
         Pageable pageable = PageRequest.of(0, pagingRequest.size());
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -60,8 +60,8 @@ public class MyFoodTruckMenuService {
     public void registerMenu(Long ownerId, Long foodTruckId, RegisterMenuRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(
-                        foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))
+        FoodTruck foodTruck = foodTruckRepository.findByFoodTruckIdAndOwnerIdAndFoodTruckStatus(
+                        foodTruckId, ownerId, FoodTruckStatus.ON)
                 .orElseThrow(() -> new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED));
 
         Menu menu = Menu.create(
@@ -77,7 +77,7 @@ public class MyFoodTruckMenuService {
     public void updateMenuStatus(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuStatusRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -92,7 +92,7 @@ public class MyFoodTruckMenuService {
     public void updateMenu(Long ownerId, Long foodTruckId, Long menuId, UpdateMenuRequest request) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 
@@ -106,7 +106,7 @@ public class MyFoodTruckMenuService {
     public void deleteMenu(Long ownerId, Long foodTruckId, Long menuId) {
 
         // 본인 소유인지, 푸드트럭이 승인 완료된 상태인지 검증
-        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatusIn(foodTruckId, ownerId, List.of(FoodTruckStatus.ON, FoodTruckStatus.OFF))) {
+        if (!foodTruckRepository.existsByFoodTruckIdAndOwnerIdAndFoodTruckStatus(foodTruckId, ownerId, FoodTruckStatus.ON)) {
             throw new BusinessException(ErrorCode.FOOD_TRUCK_NOT_APPROVED);
         }
 

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/OwnerController.java
@@ -285,4 +285,18 @@ public class OwnerController {
         ownerService.deleteMenu(ownerId, foodTruckId, menuId);
         return BaseResponse.ok(null);
     }
+
+    @Operation(
+            summary = "사장님 등록(서류 검증) & 푸드트럭 최초 등록",
+            description = "푸드트럭을 최초로 등록하는 API 입니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.CREATE_NEW_FOOD_TRUCK)
+    @PostMapping
+    public BaseResponse<Void> createNewFoodTruck(
+            @Valid @RequestBody final FoodTruckCreateRequest request,
+            @Parameter(hidden = true) @UserId final Long ownerId
+    ) {
+        ownerService.createNewFoodTruck(ownerId, request);
+        return BaseResponse.ok(null);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/FoodTruckCreateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/FoodTruckCreateRequest.java
@@ -19,7 +19,7 @@ public record FoodTruckCreateRequest(
 
         // 기타 서류 5장
         @Schema(description = "기타 서류 URL 목록 (정확히 5장)", example = "[\"https://cdn.chacall.com/foodtrucks/osori/doc1.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc2.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc3.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc4.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc5.jpg\"]")
-        @Size(min = 5, max = 5, message = "기타 서류는 반드시 5장까지 업로드 가능합니다.")
+        @Size(min = 5, max = 5, message = "기타 서류는 정확히 5장을 업로드해야합니다.")
         List<@NotBlank String> otherDocumentUrls
 ) {
 }

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/FoodTruckCreateRequest.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/request/FoodTruckCreateRequest.java
@@ -1,0 +1,25 @@
+package konkuk.chacall.domain.owner.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record FoodTruckCreateRequest(
+        @Schema(description = "푸드트럭 이름", example = "차콜 푸드트럭")
+        @NotBlank(message = "푸드트럭 이름은 필수입니다.")
+        @Size(min = 1, max = 10, message = "푸드트럭 이름은 1~10자입니다.")
+        String name,
+
+        // 사업자등록증 1장
+        @Schema(description = "사업자등록증 url", example = "https://cdn.chacall.com/foodtrucks/osori/business-license.jpg")
+        @NotBlank(message = "사업자등록증 url 은 필수입니다.")
+        String businessRegistrationUrl,
+
+        // 기타 서류 5장
+        @Schema(description = "기타 서류 URL 목록 (정확히 5장)", example = "[\"https://cdn.chacall.com/foodtrucks/osori/doc1.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc2.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc3.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc4.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc5.jpg\"]")
+        @Size(min = 5, max = 5, message = "기타 서류는 반드시 5장까지 업로드 가능합니다.")
+        List<@NotBlank String> otherDocumentUrls
+) {
+}

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckMenuResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckMenuResponse.java
@@ -15,7 +15,7 @@ public record MyFoodTruckMenuResponse(
         String description,
         @Schema(description = "이미지 URL", example = "https://cdn.example.com/menus/101.jpg")
         String imageUrl,
-        @Schema(description = "메뉴 표시 여부", example = "ON/OFF")
+        @Schema(description = "메뉴 표시 여부", example = "APPROVED/OFF")
         String status
 ) {
     public static MyFoodTruckMenuResponse from(Menu menu) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckMenuResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckMenuResponse.java
@@ -15,7 +15,7 @@ public record MyFoodTruckMenuResponse(
         String description,
         @Schema(description = "이미지 URL", example = "https://cdn.example.com/menus/101.jpg")
         String imageUrl,
-        @Schema(description = "메뉴 표시 여부", example = "APPROVED/OFF")
+        @Schema(description = "메뉴 표시 여부", example = "ON/OFF")
         String status
 ) {
     public static MyFoodTruckMenuResponse from(Menu menu) {

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
@@ -9,13 +9,13 @@ import java.util.List;
 public record MyFoodTruckResponse(
         @Schema(description = "푸드트럭 식별자", example = "1")
         Long foodTruckId,
-        @Schema(description = "푸드트럭 이미지", example = "image.png")
+        @Schema(description = "푸드트럭 이미지", example = "image.png", nullable = true)
         String imageUrl,
         @Schema(description = "푸드트럭 이름", example = "차콜 푸드트럭")
         String name,
-        @Schema(description = "푸드트럭 설명", example = "저희 푸드트럭은 10년간 이어져온...")
+        @Schema(description = "푸드트럭 설명", example = "저희 푸드트럭은 10년간 이어져온...", nullable = true)
         String description,
-        @Schema(description = "운영 가능 시간대", example = "09:00 ~ 21:00")
+        @Schema(description = "운영 가능 시간대", example = "09:00 ~ 21:00", nullable = true)
         String activeTime,
         @Schema(description = "호출 가능 지역", example = "서울 전체, 경기도 수원시 영통구, 인천 계양구")
         String serviceArea,

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
@@ -19,7 +19,7 @@ public record MyFoodTruckResponse(
         String activeTime,
         @Schema(description = "호출 가능 지역", example = "서울 전체, 경기도 수원시 영통구, 인천 계양구")
         String serviceArea,
-        @Schema(description = "푸드트럭 표시 여부", example = "ON/OFF")
+        @Schema(description = "푸드트럭 표시 여부", example = "APPROVED/OFF")
         String status
 ) {
         /**

--- a/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/owner/presentation/dto/response/MyFoodTruckResponse.java
@@ -19,7 +19,7 @@ public record MyFoodTruckResponse(
         String activeTime,
         @Schema(description = "호출 가능 지역", example = "서울 전체, 경기도 수원시 영통구, 인천 계양구")
         String serviceArea,
-        @Schema(description = "푸드트럭 표시 여부", example = "APPROVED/OFF")
+        @Schema(description = "푸드트럭 표시 여부", example = "ON/OFF")
         String status
 ) {
         /**

--- a/src/main/java/konkuk/chacall/domain/region/application/query/RegionQueryService.java
+++ b/src/main/java/konkuk/chacall/domain/region/application/query/RegionQueryService.java
@@ -25,7 +25,7 @@ public class RegionQueryService {
         List<Region> regions = regionRepository.findRegions(request.depth(), request.parentCode());
 
         return regions.stream()
-                .map(region -> RegionResponse.of(region.getName(), region.getRegionCode()))
+                .map(region -> RegionResponse.of(region.getName(), region.getRegionId(), region.getRegionCode()))
                 .toList();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/region/application/search/RegionSearchService.java
+++ b/src/main/java/konkuk/chacall/domain/region/application/search/RegionSearchService.java
@@ -19,7 +19,7 @@ public class RegionSearchService {
         List<Region> regions = regionRepository.searchSubRegionsByFullName(request.keyword().trim());
 
         return regions.stream()
-                .map(region -> RegionResponse.of(region.getFullName(), region.getRegionCode()))
+                .map(region -> RegionResponse.of(region.getFullName(), region.getRegionId(), region.getRegionCode()))
                 .toList();
     }
 

--- a/src/main/java/konkuk/chacall/domain/region/presentation/dto/response/RegionResponse.java
+++ b/src/main/java/konkuk/chacall/domain/region/presentation/dto/response/RegionResponse.java
@@ -6,12 +6,16 @@ public record RegionResponse(
         @Schema(description = "지역 이름", example = "서울")
         String name,
 
+        @Schema(description = "지역 식별자 (PK값)", example = "1")
+        Long id,
+
         @Schema(description = "지역 행정동 코드", example = "11")
         Long code
 ) {
-    public static RegionResponse of(String name, Long regionCode) {
+    public static RegionResponse of(String name, Long id, Long regionCode) {
         return new RegionResponse(
                 name,
+                id,
                 regionCode);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/ApproveFoodTruckStatusRequest.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/request/ApproveFoodTruckStatusRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotNull;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 
 public record ApproveFoodTruckStatusRequest(
-        @Schema(description = "변경할 푸드트럭 승인 상태", example = "OFF")
+        @Schema(description = "변경할 푸드트럭 승인 상태", example = "APPROVED")
         @NotNull(message = "승인 상태는 필수입니다.")
         FoodTruckStatus status
 ) {}

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -125,6 +125,10 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_APPROVED,
             MENU_NOT_FOUND
     ))),
+    CREATE_NEW_FOOD_TRUCK(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN
+    ))),
 
 
     // Member

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -10,7 +10,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
## #️⃣연관된 이슈

> closes #48 

## 📝작업 내용

사장님 등록 & 푸드트럭을 최초 등록 API 를 구현하였습니다.

### 푸드트럭 최초 등록
푸드트럭을 최초 등록할 시 푸드트럭의 이름, 사업자 등록증, 기타서류 5가지를 입력받아야합니다.
이 때 사업자 등록증과 기타서류를 푸드트럭 테이블이 아닌 별도의 테이블로 분리해서 관리하는 것이 더 나을 것 같다고 합의되었기에, `푸드트럭 서류` 테이블을 새롭게 만들어서 푸드트럭과 1 : N 관계를 맺어주었습니다.

또한 사업자 등록증과 기타 서류를 서로 구분해주기 위해서 DocumentType 이라는 ENUM 을 만들어두었습니다.
<img width="515" height="489" alt="스크린샷 2025-10-21 오후 4 54 43" src="https://github.com/user-attachments/assets/74cd4e28-34fd-4c85-96a6-a5de865cb91b" />


<img width="462" height="390" alt="스크린샷 2025-10-21 오후 4 55 40" src="https://github.com/user-attachments/assets/58195898-7116-454a-aee5-6b99e6bb0f93" />

이건 실제로 푸드트럭을 등록하고, 관리자로부터 승인된 이후의 모습입니다.

이 외에 구현상의 별다른 이슈는 없었습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)
ddl-auto update 로 설정하면, 기존에 nullable=false 로 설정되어있던 컬럼들을 nullable=true 로 바꾸는 변경사항이 제대로 DB 에 반영이 되지 않아서 ddl-auto create 으로 설정해두었으니 확인 부탁드립니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리즈 노트

* **새로운 기능**
  * 식푸드트럭 소유자가 신규 푸드트럭 등록 시 사업자 등록증 및 추가 서류 업로드 기능 추가
  * 푸드트럭 승인 상태 시스템 개선 (승인 대기, 거절, 승인 상태로 통합)
  * 거절 사유 기록 기능 추가
  * 지역 정보에 고유 식별자 추가

* **개선 사항**
  * 푸드트럭 상태 검증 로직 최적화
  * 서류 관리 및 추적 기능 강화

<!-- end of auto-generated comment: release notes by coderabbit.ai -->