### PR TITLE
[FEAT] 푸드트럭 상세조회 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -78,4 +78,10 @@ public class FoodTruckService {
 
         foodTruckImageService.deleteFoodTruckImagesFromS3(owner, foodTruckId, request);
     }
+
+    public FoodTruckDetailResponse getFoodTruckDetails(Long memberId, Long foodTruckId) {
+        User member = memberValidator.validateAndGetMember(memberId);
+
+        return foodTruckInfoService.getFoodTruckDetails(member, foodTruckId);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -21,6 +21,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
@@ -83,5 +85,11 @@ public class FoodTruckService {
         User member = memberValidator.validateAndGetMember(memberId);
 
         return foodTruckInfoService.getFoodTruckDetails(member, foodTruckId);
+    }
+
+    public List<FoodTruckMenuResponse> searchFoodTruckMenus(Long foodTruckId, String keyword, Long memberId) {
+        User member = memberValidator.validateAndGetMember(memberId);
+
+        return foodTruckMenuService.searchFoodTruckMenus(foodTruckId, keyword, member);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -9,6 +9,7 @@ import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckServiceAreaRep
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.DateRangeRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.UpdateFoodTruckInfoRequest;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckDetailResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
 import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
 import konkuk.chacall.domain.region.domain.model.Region;
@@ -132,5 +133,23 @@ public class FoodTruckInfoService {
 
             foodTruckServiceAreaRepository.deleteAll(serviceAreasToRemove);
         }
+    }
+
+    public FoodTruckDetailResponse getFoodTruckDetails(User member, Long foodTruckId) {
+        FoodTruck foodTruck = foodTruckRepository.findById(foodTruckId)
+                .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
+
+        switch(member.getRole()) {
+            case MEMBER -> foodTruck.validateViewableStatusForMember();
+            case OWNER -> foodTruck.validateOwner(member.getUserId());
+            case ADMIN -> {}
+        }
+
+        List<FoodTruckServiceArea> foodTruckServiceAreas = foodTruckServiceAreaRepository.findAllByFoodTruckId(foodTruckId);
+        List<AvailableDate> availableDates = availableDateRepository.findAllByFoodTruckId(foodTruckId);
+
+        boolean isSaved = savedFoodTruckRepository.existsByMemberIdAndFoodTruckId(member.getUserId(), foodTruckId);
+
+        return FoodTruckDetailResponse.from(foodTruck, foodTruckServiceAreas, availableDates, isSaved);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -143,7 +143,7 @@ public class FoodTruckInfoService {
 
         switch(member.getRole()) {
             case MEMBER -> foodTruck.validateViewableStatusForMember();
-            case OWNER -> foodTruck.vaildateViewableStatusForOwner(member.getUserId());
+            case OWNER -> foodTruck.validateViewableStatusForOwner(member.getUserId());
             case ADMIN -> {}
         }
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -141,7 +141,7 @@ public class FoodTruckInfoService {
 
         switch(member.getRole()) {
             case MEMBER -> foodTruck.validateViewableStatusForMember();
-            case OWNER -> foodTruck.validateOwner(member.getUserId());
+            case OWNER -> foodTruck.vaildateViewableStatusForOwner(member.getUserId());
             case ADMIN -> {}
         }
 

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -139,6 +139,8 @@ public class FoodTruckInfoService {
         FoodTruck foodTruck = foodTruckRepository.findById(foodTruckId)
                 .orElseThrow(() -> new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND));
 
+        foodTruck.validateApprovedStatus();
+
         switch(member.getRole()) {
             case MEMBER -> foodTruck.validateViewableStatusForMember();
             case OWNER -> foodTruck.vaildateViewableStatusForOwner(member.getUserId());

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/menu/FoodTruckMenuService.java
@@ -3,10 +3,9 @@ package konkuk.chacall.domain.foodtruck.application.menu;
 import konkuk.chacall.domain.foodtruck.domain.model.Menu;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
 import konkuk.chacall.domain.foodtruck.domain.repository.MenuRepository;
-import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckMenuRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckMenuResponse;
-import konkuk.chacall.domain.owner.presentation.dto.response.MyFoodTruckMenuResponse;
+import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.global.common.dto.CursorPagingRequest;
 import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.dto.SortType;
@@ -47,5 +46,17 @@ public class FoodTruckMenuService {
                 .toList();
 
         return CursorPagingResponse.of(content, FoodTruckMenuResponse::menuId, menuSlice.hasNext());
+    }
+
+    public List<FoodTruckMenuResponse> searchFoodTruckMenus(Long foodTruckId, String keyword, User member) {
+        if(!foodTruckRepository.existsById(foodTruckId)) {
+            throw new EntityNotFoundException(ErrorCode.FOOD_TRUCK_NOT_FOUND);
+        }
+
+        List<Menu> menus = menuRepository.searchByKeyword(foodTruckId, keyword);
+
+        return menus.stream()
+                .map(FoodTruckMenuResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/AvailableDate.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/AvailableDate.java
@@ -36,4 +36,10 @@ public class AvailableDate extends BaseEntity {
                 .foodTruck(foodTruck)
                 .build();
     }
+
+    public String formatDate() {
+        return startAt + " ~ " + endAt;
+    }
+
+
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -172,8 +172,6 @@ public class FoodTruck extends BaseEntity {
     public void vaildateViewableStatusForOwner(Long userId) {
         if(!isOwnedBy(userId)) { // 자신이 소유한 푸드트럭이 아니면
             validateViewableStatusForMember();
-        } else { // 자신이 소유한 푸드트럭이면
-            validateOwner(userId);
         }
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -143,6 +143,13 @@ public class FoodTruck extends BaseEntity {
                 .collect(Collectors.joining(", "));
     }
 
+    // 푸드트럭의 운영 기간을 반환해주는 메서드
+    public List<String> getAvailableDates(List<AvailableDate> availableDateList) {
+        return availableDateList.stream()
+                .map(AvailableDate::formatDate)
+                .collect(Collectors.toList());
+    }
+
     public void changeViewedStatus(FoodTruckViewedStatus targetViewedStatus) {
         if(this.foodTruckViewedStatus == targetViewedStatus) {
             throw new DomainRuleException(ErrorCode.INVALID_FOOD_TRUCK_STATUS_TRANSITION);
@@ -154,5 +161,11 @@ public class FoodTruck extends BaseEntity {
         }
 
         this.foodTruckViewedStatus = targetViewedStatus;
+    }
+
+    public void validateViewableStatusForMember() {
+        if (this.foodTruckViewedStatus != FoodTruckViewedStatus.ON) {
+            throw new DomainRuleException(ErrorCode.FOOD_TRUCK_NOT_VIEWABLE);
+        }
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -168,4 +168,12 @@ public class FoodTruck extends BaseEntity {
             throw new DomainRuleException(ErrorCode.FOOD_TRUCK_NOT_VIEWABLE);
         }
     }
+
+    public void vaildateViewableStatusForOwner(Long userId) {
+        if(!isOwnedBy(userId)) { // 자신이 소유한 푸드트럭이 아니면
+            validateViewableStatusForMember();
+        } else { // 자신이 소유한 푸드트럭이면
+            validateOwner(userId);
+        }
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/model/FoodTruck.java
@@ -169,7 +169,7 @@ public class FoodTruck extends BaseEntity {
         }
     }
 
-    public void vaildateViewableStatusForOwner(Long userId) {
+    public void validateViewableStatusForOwner(Long userId) {
         if(!isOwnedBy(userId)) { // 자신이 소유한 푸드트럭이 아니면
             validateViewableStatusForMember();
         }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/AvailableDateRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/AvailableDateRepository.java
@@ -6,9 +6,14 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
+
 public interface AvailableDateRepository extends JpaRepository<AvailableDate, Long> {
 
     @Modifying
     @Query("DELETE FROM AvailableDate ad WHERE ad.foodTruck.foodTruckId = :foodTruckId")
     void deleteAllByFoodTruckId(@Param("foodTruckId") Long foodTruckId);
+
+    @Query("SELECT ad FROM AvailableDate ad WHERE ad.foodTruck.foodTruckId = :foodTruckId")
+    List<AvailableDate> findAllByFoodTruckId(Long foodTruckId);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
@@ -76,7 +76,8 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             from Menu m
             where m.foodTruck.foodTruckId = :foodTruckId
               and m.name like concat('%', :keyword, '%')
-              and m.menuViewedStatus = konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus.ON
+              and m.menuViewedStatus = konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus.ON 
+            order by m.menuId desc
             """)
     List<Menu> searchByKeyword(Long foodTruckId, String keyword);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/MenuRepository.java
@@ -1,7 +1,6 @@
 package konkuk.chacall.domain.foodtruck.domain.repository;
 
 import konkuk.chacall.domain.foodtruck.domain.model.Menu;
-import konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,6 +8,7 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MenuRepository extends JpaRepository<Menu, Long> {
@@ -70,4 +70,13 @@ public interface MenuRepository extends JpaRepository<Menu, Long> {
             """)
     Optional<Menu> findByMenuIdAndFoodTruckId(@Param("menuId") Long menuId,
                                               @Param("foodTruckId") Long foodTruckId);
+
+    @Query("""
+            select m
+            from Menu m
+            where m.foodTruck.foodTruckId = :foodTruckId
+              and m.name like concat('%', :keyword, '%')
+              and m.menuViewedStatus = konkuk.chacall.domain.foodtruck.domain.value.MenuViewedStatus.ON
+            """)
+    List<Menu> searchByKeyword(Long foodTruckId, String keyword);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -137,7 +137,7 @@ public class FoodTruckController {
             description = "푸드트럭의 상세 정보를 조회합니다."
     )
     @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_DETAILS)
-    @GetMapping("/{foodTruckId}/details")
+    @GetMapping("/{foodTruckId}")
     public BaseResponse<FoodTruckDetailResponse> getFoodTruckDetails(
             @Parameter(description = "푸드트럭 ID", example = "1") @PathVariable final Long foodTruckId,
             @Parameter(hidden = true) @UserId final Long memberId

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -25,6 +25,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Tag(name = "FoodTruck API", description = "푸드트럭 관련 API")
 @RestController
 @RequiredArgsConstructor
@@ -106,7 +108,7 @@ public class FoodTruckController {
             description = "승인이 완료된 나의 푸드트럭 정보를 기입하거나 수정합니다."
     )
     @ExceptionDescription(SwaggerResponseDescription.UPDATE_FOOD_TRUCK_INFO)
-    @PutMapping("{foodTruckId}")
+    @PutMapping("/{foodTruckId}")
     public BaseResponse<FoodTruckIdResponse> updateMyFoodTruckInfo(
             @Parameter(description = "푸드트럭 ID", example = "1") @PathVariable final Long foodTruckId,
             @Valid @RequestBody final UpdateFoodTruckInfoRequest request,
@@ -120,7 +122,7 @@ public class FoodTruckController {
             description = "S3에서 푸드트럭/메뉴 이미지 객체를 삭제합니다. 사용자가 기존 푸드트럭/메뉴 이미지를 삭제했을 경우 호출해주세요."
     )
     @ExceptionDescription(SwaggerResponseDescription.DELETE_FOOD_TRUCK_IMAGES)
-    @DeleteMapping("{foodTruckId}/images")
+    @DeleteMapping("/{foodTruckId}/images")
     public BaseResponse<Void> deleteFoodTruckImagesFromS3(
             @Parameter(description = "푸드트럭 ID", example = "1") @PathVariable final Long foodTruckId,
             @Valid @RequestBody final DeleteFoodTruckImagesRequest request,
@@ -143,5 +145,17 @@ public class FoodTruckController {
         return BaseResponse.ok(foodTruckService.getFoodTruckDetails(memberId, foodTruckId));
     }
 
-
+    @Operation(
+            summary = "푸드트럭 메뉴 검색",
+            description = "푸드트럭 메뉴를 이름으로 검색합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.SEARCH_FOOD_TRUCK_MENUS)
+    @GetMapping("/{foodTruckId}/menus/search")
+    public BaseResponse<List<FoodTruckMenuResponse>> searchFoodTruckMenus(
+            @Parameter(description = "푸드트럭 ID", example = "1") @PathVariable final Long foodTruckId,
+            @Parameter(description = "검색 키워드", example = "치킨") @RequestParam("keyword") final String keyword,
+            @Parameter(hidden = true) @UserId final Long memberId
+    ) {
+        return BaseResponse.ok(foodTruckService.searchFoodTruckMenus(foodTruckId, keyword, memberId));
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -130,5 +130,18 @@ public class FoodTruckController {
         return BaseResponse.ok(null);
     }
 
+    @Operation(
+            summary = "푸드트럭 상세조회",
+            description = "푸드트럭의 상세 정보를 조회합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.GET_FOOD_TRUCK_DETAILS)
+    @GetMapping("/{foodTruckId}/details")
+    public BaseResponse<FoodTruckDetailResponse> getFoodTruckDetails(
+            @Parameter(description = "푸드트럭 ID", example = "1") @PathVariable final Long foodTruckId,
+            @Parameter(hidden = true) @UserId final Long memberId
+    ) {
+        return BaseResponse.ok(foodTruckService.getFoodTruckDetails(memberId, foodTruckId));
+    }
+
 
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckDetailResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckDetailResponse.java
@@ -1,0 +1,69 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.chacall.domain.foodtruck.domain.model.AvailableDate;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckServiceArea;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckInfo;
+
+import java.util.List;
+
+public record FoodTruckDetailResponse(
+        @Schema(description = "푸드트럭 식별자", example = "1")
+        Long foodTruckId,
+        @Schema(description = "푸드트럭 이름", example = "푸드트럭")
+        String name,
+        @Schema(description = "푸드트럭 설명", example = "맛있는 푸드트럭입니다.")
+        String description,
+        @Schema(description = "푸드트럭 전화번호", example = "010-1234-5678")
+        String phoneNumber,
+        @Schema(description = "푸드트럭 활동 시간", example = "09:00-20:00")
+        String activeTime,
+        @Schema(description = "시간 협의 필요 여부", example = "false")
+        Boolean timeDiscussRequired,
+        @Schema(description = "호출 가능 지역", example = "서울 광진구, 서울 강남구, 서울 영등포구")
+        String serviceAreas,
+        @Schema(description = "푸드트럭 메뉴 카테고리 (라벨 리스트)", example = "[\"한식\",\"분식\"]")
+        List<String> menuCategories,
+        @Schema(description = "푸드트럭 제공 가능 수량", example = "200인분 미만")
+        String availableQuantity,
+        @Schema(description = "전기 사용 필요 여부", example = "필요")
+        String needElectricity,
+        @Schema(description = "결제 방법", example = "무관")
+        String paymentMethod,
+        @Schema(description = "푸드트럭 제공 가능 날짜 리스트", example = "[\"2025-10-01 ~ 2025-10-10\",\"2025-11-01 ~ 2025-11-10\"]")
+        List<String> availableDates,
+        @Schema(description = "푸드트럭 사진 URL 리스트", example = "[\"http://image.png\",\"http://image2.png\",\"http://image3.png\"]")
+        List<String> photoUrl,
+        @Schema(description = "운영 정보", example = "운영정보")
+        String operatingInfo,
+        @Schema(description = "추가 옵션 정보", example = "안녕하세요")
+        String option,
+        @Schema(description = "푸드트럭 평균 평점", example = "4.5")
+        Double averageRating,
+        @Schema(description = "현재 사용자가 저장한 푸드트럭인지 여부", example = "true")
+        Boolean isSaved
+) {
+    public static FoodTruckDetailResponse from(FoodTruck foodTruck, List<FoodTruckServiceArea> serviceAreas, List<AvailableDate> availableDates, Boolean isSaved) {
+        FoodTruckInfo foodTruckInfo = foodTruck.getFoodTruckInfo();
+        return new FoodTruckDetailResponse(
+                foodTruck.getFoodTruckId(),
+                foodTruckInfo.getName(),
+                foodTruckInfo.getDescription(),
+                foodTruckInfo.getPhoneNumber(),
+                foodTruckInfo.getActiveTime(),
+                foodTruckInfo.getTimeDiscussRequired(),
+                foodTruck.getServiceAreas(serviceAreas),
+                foodTruckInfo.getMenuCategoryList().getMenuCategoryLabelList(),
+                foodTruckInfo.getAvailableQuantity().getValue(),
+                foodTruckInfo.getNeedElectricity().getValue(),
+                foodTruckInfo.getPaymentMethod().getValue(),
+                foodTruck.getAvailableDates(availableDates),
+                foodTruckInfo.getFoodTruckPhotoList().getUrls(),
+                foodTruckInfo.getOperatingInfo(),
+                foodTruckInfo.getOption(),
+                foodTruck.getRatingInfo().getAverageRating(),
+                isSaved
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
@@ -52,9 +52,10 @@ public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, 
                 select exists (
                     select s
                       from SavedFoodTruck s
-                     where s.member.userId = :memberId
+                     where s.member.userId = :userId
                        and s.foodTruck.foodTruckId = :foodTruckId
                 )
             """)
-    boolean existsByMemberIdAndFoodTruckId(Long userId, Long foodTruckId);
+    boolean existsByMemberIdAndFoodTruckId(@Param("userId") Long userId,
+                                           @Param("foodTruckId") Long foodTruckId);
 }

--- a/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
@@ -48,4 +48,13 @@ public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, 
     Set<Long> findSavedTruckIdsIn(@Param("userId") Long userId,
                                   @Param("foodTruckIds") List<Long> foodTruckIds);
 
+    @Query("""
+                select exists (
+                    select s
+                      from SavedFoodTruck s
+                     where s.member.userId = :memberId
+                       and s.foodTruck.foodTruckId = :foodTruckId
+                )
+            """)
+    boolean existsByMemberIdAndFoodTruckId(Long userId, Long foodTruckId);
 }

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode implements ResponseCode {
     AVAILABLE_QUANTITY_MISMATCH(HttpStatus.BAD_REQUEST, 110007, "제조 가능 수량 값이 올바르지 않습니다."),
     NEED_ELECTRICITY_MISMATCH(HttpStatus.BAD_REQUEST, 110008, "전기 사용 여부 값이 올바르지 않습니다."),
     PAYMENT_METHOD_MISMATCH(HttpStatus.BAD_REQUEST, 110009, "결제 수단 값이 올바르지 않습니다."),
+    FOOD_TRUCK_NOT_VIEWABLE(HttpStatus.FORBIDDEN, 110010, "노출 가능한 상태의 푸드트럭이 아닙니다."),
 
     /**
      * Image

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -253,6 +253,11 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_OWNED,
             FOOD_TRUCK_NOT_VIEWABLE
     ))),
+    SEARCH_FOOD_TRUCK_MENUS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_FOUND
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -246,6 +246,13 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_FOUND,
             FOOD_TRUCK_NOT_OWNED
     ))),
+    GET_FOOD_TRUCK_DETAILS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN,
+            FOOD_TRUCK_NOT_FOUND,
+            FOOD_TRUCK_NOT_OWNED,
+            FOOD_TRUCK_NOT_VIEWABLE
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -251,7 +251,8 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             FOOD_TRUCK_NOT_FOUND,
             FOOD_TRUCK_NOT_OWNED,
-            FOOD_TRUCK_NOT_VIEWABLE
+            FOOD_TRUCK_NOT_VIEWABLE,
+            FOOD_TRUCK_NOT_APPROVED
     ))),
     SEARCH_FOOD_TRUCK_MENUS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #53 

## 📝작업 내용

단순 조회라서 딱히 특이사항이 없었습니다.

유효성 검증시에 사용자의 역할에 따라 다르게 검증하였습니다.
- 일반 유저 -> 푸드트럭 노출 상태가 ON일 경우에만 조회 가능
- 사장님 -> 본인 소유 푸드트럭일 경우 노출 상태 상관없이 가능 / 아닐 경우 노출 상태가 ON일 경우만 조회 가능
- 관리자 -> 유효성 검증 패스

추가적으로 찬영님 요청에 따라 메뉴 검색 API를 구현하였습니다. 단순히 like 문을 사용해서 구현하였고, 반환 타입은 찬영님과의 합의하에 리스트 객체로 감싸지 않고 바로 리스트를 반환하도록 구현하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 푸드트럭 상세 조회 추가: 운영 시간, 서비스 지역, 메뉴 목록, 사진, 평점 및 사용자의 저장 여부 포함.
  * 메뉴 키워드 검색 추가: 특정 푸드트럭 내 메뉴를 키워드로 검색 가능.
  * 가용 일자 표시 개선: 가용 일자가 "시작 ~ 종료" 형식 문자열로 제공.

* **문서**
  * API 응답 및 오류 설명에 상세 조회·메뉴 검색 관련 상태 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->