### PR TITLE
[FEAT] 운영자용 서비스내에 모든 푸드트럭 조회 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckDocumentRepository.java
@@ -2,6 +2,16 @@ package konkuk.chacall.domain.foodtruck.domain.repository;
 
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckDocument;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Collection;
+import java.util.List;
 
 public interface FoodTruckDocumentRepository extends JpaRepository<FoodTruckDocument, Long> {
+    @Query("""
+            SELECT ftd
+            FROM FoodTruckDocument ftd
+            WHERE ftd.foodTruck.foodTruckId IN :foodTruckIds
+            """)
+    List<FoodTruckDocument> findAllInFoodTruckIds(List<Long> foodTruckIds);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -5,10 +5,12 @@ import konkuk.chacall.domain.foodtruck.domain.repository.infra.FoodTruckSearchRe
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, FoodTruckSearchRepository {
@@ -46,4 +48,6 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
 
     boolean existsByFoodTruckInfo_Name(String name);
 
+    @EntityGraph(attributePaths = {"owner"})
+    List<FoodTruck> findAllByFoodTruckStatus(FoodTruckStatus foodTruckStatus);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -50,4 +50,7 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
 
     @EntityGraph(attributePaths = {"owner"})
     List<FoodTruck> findAllByFoodTruckStatus(FoodTruckStatus foodTruckStatus);
+
+    @EntityGraph(attributePaths = {"owner"})
+    List<FoodTruck> findAll();
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/value/FoodTruckStatus.java
@@ -1,5 +1,8 @@
 package konkuk.chacall.domain.foodtruck.domain.value;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import konkuk.chacall.global.common.exception.DomainRuleException;
+import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -11,4 +14,13 @@ public enum FoodTruckStatus {
     REJECTED("승인 거부");     // 관리자가 승인을 거부한 상태
 
     private final String description;
+
+    public static FoodTruckStatus from(String status) {
+        for (FoodTruckStatus foodTruckStatus : FoodTruckStatus.values()) {
+            if (foodTruckStatus.getDescription().equals(status)) {
+                return foodTruckStatus;
+            }
+        }
+        throw new DomainRuleException(ErrorCode.FOOD_TRUCK_STATUS_MISMATCH);
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/user/application/UserService.java
+++ b/src/main/java/konkuk/chacall/domain/user/application/UserService.java
@@ -1,11 +1,13 @@
 package konkuk.chacall.domain.user.application;
 
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
 import konkuk.chacall.domain.user.application.admin.AdminService;
 import konkuk.chacall.domain.user.application.validator.AdminValidator;
 import konkuk.chacall.domain.user.presentation.dto.request.ApproveFoodTruckStatusRequest;
 import konkuk.chacall.domain.user.domain.model.User;
 import konkuk.chacall.domain.user.domain.repository.UserRepository;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import konkuk.chacall.domain.user.presentation.dto.response.FoodTruckForAdminResponse;
 import konkuk.chacall.domain.user.presentation.dto.response.UserResponse;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
@@ -16,6 +18,8 @@ import konkuk.chacall.global.common.storage.util.KeyUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -61,5 +65,11 @@ public class UserService {
                 USER_PROFILE_IMAGE_MAX_COUNT,
                 KeyUtils::buildUserProfileImageKey
         );
+    }
+
+    public List<FoodTruckForAdminResponse> getAllFoodTrucks(Long userId, String status) {
+        adminValidator.validateAdmin(userId);
+
+        return adminService.getAllFoodTrucks(status);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/application/admin/AdminService.java
+++ b/src/main/java/konkuk/chacall/domain/user/application/admin/AdminService.java
@@ -1,18 +1,27 @@
 package konkuk.chacall.domain.user.application.admin;
 
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruckDocument;
+import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckDocumentRepository;
 import konkuk.chacall.domain.foodtruck.domain.repository.FoodTruckRepository;
+import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckStatus;
 import konkuk.chacall.domain.user.presentation.dto.request.ApproveFoodTruckStatusRequest;
+import konkuk.chacall.domain.user.presentation.dto.response.FoodTruckForAdminResponse;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class AdminService {
 
     private final FoodTruckRepository foodTruckRepository;
+    private final FoodTruckDocumentRepository foodTruckDocumentRepository;
 
     public void approveFoodTruckStatus(Long foodTruckId, ApproveFoodTruckStatusRequest request) {
         FoodTruck foodTruck = foodTruckRepository.findById(foodTruckId)
@@ -21,4 +30,34 @@ public class AdminService {
         foodTruck.approveFoodTruck(request.status());
     }
 
+    public List<FoodTruckForAdminResponse> getAllFoodTrucks(String status) {
+        List<FoodTruck> foodTruckList;
+
+        if(status != null && !status.isEmpty()) {
+            FoodTruckStatus foodTruckStatus = FoodTruckStatus.from(status);
+            foodTruckList = foodTruckRepository.findAllByFoodTruckStatus(foodTruckStatus);
+        } else {
+            foodTruckList = foodTruckRepository.findAll();
+        }
+
+        Map<Long, List<FoodTruckDocument>> documentMap = foodTruckDocumentRepository.findAllInFoodTruckIds(
+                        foodTruckList.stream()
+                                .map(FoodTruck::getFoodTruckId)
+                                .toList()
+                ).stream()
+                .collect(
+                        Collectors.groupingBy(document -> document.getFoodTruck().getFoodTruckId())
+                );
+
+
+        return foodTruckList.stream()
+                .map(foodTruck -> FoodTruckForAdminResponse.from(
+                            foodTruck,
+                            documentMap.getOrDefault(foodTruck.getFoodTruckId(), List.of()).stream()
+                                    .map(FoodTruckDocument::getDocumentUrl)
+                                    .collect(Collectors.toList())
+                    )
+                )
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -7,6 +7,7 @@ import jakarta.validation.Valid;
 import konkuk.chacall.domain.user.presentation.dto.request.ApproveFoodTruckStatusRequest;
 import konkuk.chacall.domain.user.application.UserService;
 import konkuk.chacall.domain.user.presentation.dto.request.UpdateUserInfoRequest;
+import konkuk.chacall.domain.user.presentation.dto.response.FoodTruckForAdminResponse;
 import konkuk.chacall.domain.user.presentation.dto.response.UserResponse;
 import konkuk.chacall.global.common.annotation.ExceptionDescription;
 import konkuk.chacall.global.common.annotation.UserId;
@@ -16,6 +17,8 @@ import konkuk.chacall.global.common.storage.dto.ImageResponse;
 import konkuk.chacall.global.common.swagger.SwaggerResponseDescription;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @Tag(name = "User API", description = "전체 사용자(마이페이지) 관련 API")
 @RestController
@@ -53,7 +56,7 @@ public class UserController {
     }
 
     @Operation(
-            summary = "푸드트럭 승인 상태 변경",
+            summary = "[운영자용] 푸드트럭 승인 상태 변경",
             description = "운영자 - 푸드트럭 승인 상태를 변경합니다."
     )
     @ExceptionDescription(SwaggerResponseDescription.APPROVE_FOOD_TRUCK_STATUS)
@@ -78,5 +81,19 @@ public class UserController {
             @Parameter(hidden = true) @UserId final Long userId
     ) {
         return BaseResponse.ok(userService.createUserImagePresignedUrl(userId, request));
+    }
+
+    @Operation(
+            summary = "[운영자용] 서비스내에 모든 푸드트럭 조회",
+            description = "운영자 - 서비스내에 모든 푸드트럭을 조회합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.GET_ALL_FOOD_TRUCKS)
+    @GetMapping("/admin/food-trucks")
+    public BaseResponse<List<FoodTruckForAdminResponse>> getAllFoodTrucks (
+            @Parameter(hidden = true) @UserId final Long userId,
+            @Parameter(description = "푸드트럭 승인 상태 필터링 (APPROVED, PENDING, REJECTED) / 안 보낼 경우 전체", example = "APPROVED")
+            @RequestParam(required = false) final String status
+    ) {
+        return BaseResponse.ok(userService.getAllFoodTrucks(userId, status));
     }
 }

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -91,7 +91,7 @@ public class UserController {
     @GetMapping("/admin/food-trucks")
     public BaseResponse<List<FoodTruckForAdminResponse>> getAllFoodTrucks (
             @Parameter(hidden = true) @UserId final Long userId,
-            @Parameter(description = "푸드트럭 승인 상태 필터링 (APPROVED, PENDING, REJECTED) / 안 보낼 경우 전체", example = "APPROVED")
+            @Parameter(description = "푸드트럭 승인 상태 필터링 (승인 대기, 승인 완료, 승인 거절)", example = "승인 대기")
             @RequestParam(required = false) final String status
     ) {
         return BaseResponse.ok(userService.getAllFoodTrucks(userId, status));

--- a/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/UserController.java
@@ -91,7 +91,7 @@ public class UserController {
     @GetMapping("/admin/food-trucks")
     public BaseResponse<List<FoodTruckForAdminResponse>> getAllFoodTrucks (
             @Parameter(hidden = true) @UserId final Long userId,
-            @Parameter(description = "푸드트럭 승인 상태 필터링 (승인 대기, 승인 완료, 승인 거절)", example = "승인 대기")
+            @Parameter(description = "푸드트럭 승인 상태 필터링 (승인 대기, 승인 완료, 승인 거부)", example = "승인 대기")
             @RequestParam(required = false) final String status
     ) {
         return BaseResponse.ok(userService.getAllFoodTrucks(userId, status));

--- a/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/FoodTruckForAdminResponse.java
+++ b/src/main/java/konkuk/chacall/domain/user/presentation/dto/response/FoodTruckForAdminResponse.java
@@ -1,0 +1,29 @@
+package konkuk.chacall.domain.user.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+
+import java.util.List;
+
+public record FoodTruckForAdminResponse(
+        @Schema(description = "푸드트럭 ID", example = "1")
+        Long foodTruckId,
+        @Schema(description = "푸드트럭 이름", example = "차콜 푸드트럭")
+        String foodTruckName,
+        @Schema(description = "푸드트럭 사장님 이름", example = "홍길동")
+        String ownerName,
+        @Schema(description = "푸드트럭 상태", example = "승인 대기")
+        String foodTruckStatus,
+        @Schema(description = "푸드트럭 서류 URL 목록 (사업자 등록증 포함)", example = "[\"https://cdn.chacall.com/foodtrucks/osori/doc1.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc2.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc3.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc4.jpg\", \"https://cdn.chacall.com/foodtrucks/osori/doc5.jpg\"]")
+        List<String> foodTruckDocumentUrls
+) {
+    public static FoodTruckForAdminResponse from(FoodTruck foodTruck, List<String> foodTruckDocumentUrls) {
+        return new FoodTruckForAdminResponse(
+                foodTruck.getFoodTruckId(),
+                foodTruck.getFoodTruckInfo().getName(),
+                foodTruck.getOwner().getName(),
+                foodTruck.getFoodTruckStatus().getDescription(),
+                foodTruckDocumentUrls
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
+++ b/src/main/java/konkuk/chacall/global/common/exception/code/ErrorCode.java
@@ -83,6 +83,7 @@ public enum ErrorCode implements ResponseCode {
     AVAILABLE_QUANTITY_MISMATCH(HttpStatus.BAD_REQUEST, 110007, "제조 가능 수량 값이 올바르지 않습니다."),
     NEED_ELECTRICITY_MISMATCH(HttpStatus.BAD_REQUEST, 110008, "전기 사용 여부 값이 올바르지 않습니다."),
     PAYMENT_METHOD_MISMATCH(HttpStatus.BAD_REQUEST, 110009, "결제 수단 값이 올바르지 않습니다."),
+    FOOD_TRUCK_STATUS_MISMATCH(HttpStatus.BAD_REQUEST, 110010, "푸드트럭 상태 값이 올바르지 않습니다."),
 
     /**
      * Image

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -248,7 +248,8 @@ public enum SwaggerResponseDescription {
     ))),
     GET_ALL_FOOD_TRUCKS(new LinkedHashSet<>(Set.of(
             USER_NOT_FOUND,
-            USER_FORBIDDEN
+            USER_FORBIDDEN,
+            FOOD_TRUCK_STATUS_MISMATCH
     ))),
 
     // Default

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -246,6 +246,10 @@ public enum SwaggerResponseDescription {
             FOOD_TRUCK_NOT_FOUND,
             FOOD_TRUCK_NOT_OWNED
     ))),
+    GET_ALL_FOOD_TRUCKS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #55 

## 📝작업 내용

푸드트럭 승인을 위한 관리자가 푸드트럭 목록을 조회하기 위한 API 입니다.
1. 관리자 권한 검증
2. FoodTruckStatus에 따라 모든 푸드트럭 조회 (status가 null이면 서비스 내에 모든 푸드트럭 조회) <- 이때, N+1 방지를 위해 User를 join
3. 2번에서 조회한 FoodTruck 리스트를 통해 FoodTruckDocument 조회
4. FoodTruckDocument를 FoodTruck pk로 그룹핑
5. dto 매핑

-> 총 3번의 쿼리로 호출되도록 처리하였습니다.

### 스크린샷 
<img width="1158" height="583" alt="스크린샷 2025-10-30 오전 2 19 55" src="https://github.com/user-attachments/assets/e21ee7ef-0184-42a4-bccd-d03fe294608d" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 관리자용 푸드트럭 조회 API 추가 — 상태별 필터링으로 푸드트럭 정보와 관련 문서 URL 목록 동시 조회 가능
  * 관리자 응답 형식 추가 — 푸드트럭 기본 정보와 문서 URL을 포함한 응답 제공

* **개선사항**
  * 푸드트럭 상태 값 검증 추가로 잘못된 상태 요청 시 명확한 오류 반환
  * 조회 성능 개선 — 연관 엔티티 로딩 최적화 및 문서 조회 효율화

* **문서**
  * API 응답 설명(스웨거)에 신규 응답 항목 및 관련 오류 코드 반영
<!-- end of auto-generated comment: release notes by coderabbit.ai -->