### PR TITLE
[FIX] 저장 푸드트럭 조회시 페이징 관련 이슈 해결

### DIFF
--- a/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/member/application/foodtruck/SavedFoodTruckService.java
@@ -61,10 +61,12 @@ public class SavedFoodTruckService {
 
         // 응답 DTO로 변환
         List<SavedFoodTruckResponse> responses = savedFoodTrucks.stream()
-                .map(SavedFoodTruck::getFoodTruck)
                 .map(SavedFoodTruckResponse::of)
                 .toList();
 
-        return CursorPagingResponse.of(responses, SavedFoodTruckResponse::foodTruckId, savedFoodTruckSlice.hasNext());
+        // 전체 저장 푸드트럭 갯수 조회
+        long totalSize = savedFoodTruckRepository.countByMemberAndFoodTruckViewedStatus(member, FoodTruckViewedStatus.ON);
+
+        return CursorPagingResponse.of(responses, SavedFoodTruckResponse::savedFoodTruckId, savedFoodTruckSlice.hasNext(), totalSize);
     }
 }

--- a/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/member/domain/repository/SavedFoodTruckRepository.java
@@ -58,4 +58,10 @@ public interface SavedFoodTruckRepository extends JpaRepository<SavedFoodTruck, 
             """)
     boolean existsByMemberIdAndFoodTruckId(@Param("userId") Long userId,
                                            @Param("foodTruckId") Long foodTruckId);
+
+    @Query("SELECT COUNT(sft) FROM SavedFoodTruck sft " +
+           "WHERE sft.member = :member " +
+           "AND sft.foodTruck.foodTruckViewedStatus = :status")
+    long countByMemberAndFoodTruckViewedStatus(@Param("member") User member,
+                                               @Param("status") FoodTruckViewedStatus status);
 }

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/SavedFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/SavedFoodTruckResponse.java
@@ -3,6 +3,8 @@ package konkuk.chacall.domain.member.presentation.dto.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckInfo;
+import konkuk.chacall.domain.member.domain.SavedFoodTruck;
+import net.minidev.json.annotate.JsonIgnore;
 
 import java.util.List;
 
@@ -20,9 +22,14 @@ public record SavedFoodTruckResponse(
         @Schema(description = "푸드트럭 평균 평점", example = "4.5")
         Double averageRating,
         @Schema(description = "푸드트럭 평점 수", example = "100")
-        Integer ratingCount
+        Integer ratingCount,
+
+        @JsonIgnore
+        @Schema(hidden = true, description = "커서 계산용 내부 필드 (응답에 미포함)")
+        Long savedFoodTruckId
 ) {
-    public static SavedFoodTruckResponse of(FoodTruck foodTruck) {
+    public static SavedFoodTruckResponse of(SavedFoodTruck savedFoodTruck) {
+        FoodTruck foodTruck = savedFoodTruck.getFoodTruck();
         FoodTruckInfo foodTruckInfo = foodTruck.getFoodTruckInfo();
         return new SavedFoodTruckResponse(
                 foodTruck.getFoodTruckId(),
@@ -31,7 +38,8 @@ public record SavedFoodTruckResponse(
                 foodTruckInfo.getDescription(),
                 foodTruckInfo.getMenuCategoryList().getMenuCategoryLabelList(),
                 foodTruck.getRatingInfo().getAverageRating(),
-                foodTruck.getRatingInfo().getRatingCount()
+                foodTruck.getRatingInfo().getRatingCount(),
+                savedFoodTruck.getSavedFoodTruckId()
         );
     }
 }

--- a/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/SavedFoodTruckResponse.java
+++ b/src/main/java/konkuk/chacall/domain/member/presentation/dto/response/SavedFoodTruckResponse.java
@@ -1,10 +1,10 @@
 package konkuk.chacall.domain.member.presentation.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
 import konkuk.chacall.domain.foodtruck.domain.value.FoodTruckInfo;
 import konkuk.chacall.domain.member.domain.SavedFoodTruck;
-import net.minidev.json.annotate.JsonIgnore;
 
 import java.util.List;
 

--- a/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
+++ b/src/main/java/konkuk/chacall/global/common/dto/CursorPagingResponse.java
@@ -5,14 +5,24 @@ import java.util.List;
 public record CursorPagingResponse<T>(
         List<T> content,
         Long lastCursor,
-        boolean hasNext
+        boolean hasNext,
+        Long totalSize
 ) {
     public static <T> CursorPagingResponse<T> of(
             List<T> content,
             CursorExtractor<T> extractor,
             boolean hasNext
     ) {
+        return of(content, extractor, hasNext, null);
+    }
+
+    public static <T> CursorPagingResponse<T> of(
+            List<T> content,
+            CursorExtractor<T> extractor,
+            boolean hasNext,
+            Long totalSize
+    ) {
         Long lastCursor = (content == null || content.isEmpty()) ? null : extractor.extractCursor(content.get(content.size() - 1));
-        return new CursorPagingResponse<>(content, lastCursor, hasNext);
+        return new CursorPagingResponse<>(content, lastCursor, hasNext, totalSize);
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #57 

## 📝작업 내용

- 기존에 savedFoodTruckId로 커서 키를 잡고 쿼리를 호출하는데 프론트에게 반환할때는 foodTruckId로 반환해서 뒷 페이지에서는 페이징 조회가 안되는 이슈를 해결했습니다.
- 추가적으로 프론트 요청에 따라 전체 데이터 갯수를 조회해야 하는 요구사항으로 인해 CursorPagingResponse에 totalSize 변수를 추가하고 of를 오버로딩하여 처리하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 저장된 푸드트럭 목록 조회에 전체 항목 수(totalSize) 메타데이터 추가
  * 페이징 키가 저장된 항목 기준으로 작동하도록 변경

* **리팩토링**
  * 저장된 푸드트럭에서 직접 응답 생성하도록 조회 흐름 간소화
  * 페이징 응답 구조 확장으로 총계 정보 지원

* **추가**
  * 회원별 저장된 푸드트럭 총계 조회 기능 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->