### PR TITLE
[FEAT] 홈화면 평점 높은 순 푸드트럭 조회 API 구현

### DIFF
--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/FoodTruckService.java
@@ -92,4 +92,10 @@ public class FoodTruckService {
 
         return foodTruckMenuService.searchFoodTruckMenus(foodTruckId, keyword, member);
     }
+
+    public List<FoodTruckTopRateResponse> getTopRatedFoodTrucks(Long memberId) {
+        memberValidator.validateAndGetMember(memberId);
+
+        return foodTruckInfoService.getTopRatedFoodTrucks();
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -20,6 +20,9 @@ import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.Pageable;
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
@@ -159,7 +162,7 @@ public class FoodTruckInfoService {
     }
 
     public List<FoodTruckTopRateResponse> getTopRatedFoodTrucks() {
-        return foodTruckRepository.findTopRatedFoodTrucks(TOP_RATED_FOOD_TRUCK_LIMIT).stream()
+        return foodTruckRepository.findTopRatedFoodTrucks(PageRequest.of(0, TOP_RATED_FOOD_TRUCK_LIMIT)).stream()
                 .map(FoodTruckTopRateResponse::from)
                 .toList();
     }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -20,8 +20,6 @@ import konkuk.chacall.global.common.dto.CursorPagingResponse;
 import konkuk.chacall.global.common.exception.EntityNotFoundException;
 import konkuk.chacall.global.common.exception.code.ErrorCode;
 import lombok.RequiredArgsConstructor;
-import org.springdoc.core.converters.models.Pageable;
-import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;

--- a/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/application/info/FoodTruckInfoService.java
@@ -11,6 +11,7 @@ import konkuk.chacall.domain.foodtruck.presentation.dto.request.FoodTruckSearchR
 import konkuk.chacall.domain.foodtruck.presentation.dto.request.UpdateFoodTruckInfoRequest;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckDetailResponse;
 import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckResponse;
+import konkuk.chacall.domain.foodtruck.presentation.dto.response.FoodTruckTopRateResponse;
 import konkuk.chacall.domain.member.domain.repository.SavedFoodTruckRepository;
 import konkuk.chacall.domain.region.domain.model.Region;
 import konkuk.chacall.domain.region.domain.repository.RegionRepository;
@@ -36,6 +37,8 @@ public class FoodTruckInfoService {
     private final FoodTruckServiceAreaRepository foodTruckServiceAreaRepository;
     private final AvailableDateRepository availableDateRepository;
     private final RegionRepository regionRepository;
+
+    private static final int TOP_RATED_FOOD_TRUCK_LIMIT = 7;
 
     public CursorPagingResponse<FoodTruckResponse> getFoodTrucks(Long memberId, FoodTruckSearchRequest request) {
 
@@ -153,5 +156,11 @@ public class FoodTruckInfoService {
         boolean isSaved = savedFoodTruckRepository.existsByMemberIdAndFoodTruckId(member.getUserId(), foodTruckId);
 
         return FoodTruckDetailResponse.from(foodTruck, foodTruckServiceAreas, availableDates, isSaved);
+    }
+
+    public List<FoodTruckTopRateResponse> getTopRatedFoodTrucks() {
+        return foodTruckRepository.findTopRatedFoodTrucks(TOP_RATED_FOOD_TRUCK_LIMIT).stream()
+                .map(FoodTruckTopRateResponse::from)
+                .toList();
     }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -10,7 +10,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -61,7 +60,6 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
                 where f.foodTruckStatus = 'APPROVED'
                 and f.foodTruckViewedStatus = 'ON'
                 order by f.ratingInfo.averageRating desc, f.ratingInfo.ratingCount desc
-                limit :limit
             """)
-    List<FoodTruck> findTopRatedFoodTrucks(@Param("limit") int limit);
+    List<FoodTruck> findTopRatedFoodTrucks(Pageable pageable);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/domain/repository/FoodTruckRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -53,4 +54,14 @@ public interface FoodTruckRepository extends JpaRepository<FoodTruck, Long>, Foo
 
     @EntityGraph(attributePaths = {"owner"})
     List<FoodTruck> findAll();
+
+    @Query("""
+                select f
+                from FoodTruck f
+                where f.foodTruckStatus = 'APPROVED'
+                and f.foodTruckViewedStatus = 'ON'
+                order by f.ratingInfo.averageRating desc, f.ratingInfo.ratingCount desc
+                limit :limit
+            """)
+    List<FoodTruck> findTopRatedFoodTrucks(@Param("limit") int limit);
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/FoodTruckController.java
@@ -158,4 +158,16 @@ public class FoodTruckController {
     ) {
         return BaseResponse.ok(foodTruckService.searchFoodTruckMenus(foodTruckId, keyword, memberId));
     }
+
+    @Operation(
+            summary = "[홈화면용] 평점 높은 푸드트럭 조회",
+            description = "평점이 높은 푸드트럭을 조회합니다."
+    )
+    @ExceptionDescription(SwaggerResponseDescription.GET_TOP_RATED_FOOD_TRUCKS)
+    @GetMapping("/top-rated")
+    public BaseResponse<List<FoodTruckTopRateResponse>> getTopRatedFoodTrucks(
+            @Parameter(hidden = true) @UserId final Long memberId
+    ) {
+        return BaseResponse.ok(foodTruckService.getTopRatedFoodTrucks(memberId));
+    }
 }

--- a/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckTopRateResponse.java
+++ b/src/main/java/konkuk/chacall/domain/foodtruck/presentation/dto/response/FoodTruckTopRateResponse.java
@@ -1,0 +1,24 @@
+package konkuk.chacall.domain.foodtruck.presentation.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import konkuk.chacall.domain.foodtruck.domain.model.FoodTruck;
+
+public record FoodTruckTopRateResponse(
+        @Schema(description = "푸드트럭 식별자", example = "1")
+        Long foodTruckId,
+        @Schema(description = "푸드트럭 이름", example = "푸드트럭")
+        String name,
+        @Schema(description = "푸드트럭 대표 사진 URL", example = "http://image.png")
+        String photoUrl,
+        @Schema(description = "푸드트럭 평균 평점", example = "4.5")
+        Double averageRating
+) {
+    public static FoodTruckTopRateResponse from(FoodTruck foodTruck) {
+        return new FoodTruckTopRateResponse(
+                foodTruck.getFoodTruckId(),
+                foodTruck.getFoodTruckInfo().getName(),
+                foodTruck.getFoodTruckInfo().getFoodTruckPhotoList().getMainPhotoUrl(),
+                foodTruck.getRatingInfo().getAverageRating()
+        );
+    }
+}

--- a/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
+++ b/src/main/java/konkuk/chacall/global/common/swagger/SwaggerResponseDescription.java
@@ -264,6 +264,10 @@ public enum SwaggerResponseDescription {
             USER_FORBIDDEN,
             FOOD_TRUCK_STATUS_MISMATCH
     ))),
+    GET_TOP_RATED_FOOD_TRUCKS(new LinkedHashSet<>(Set.of(
+            USER_NOT_FOUND,
+            USER_FORBIDDEN
+    ))),
 
     // Default
     DEFAULT(new LinkedHashSet<>())


### PR DESCRIPTION
## #️⃣연관된 이슈

- closes #24 

## 📝작업 내용

딱히 특이사항 없습니다.
정렬 조건은 평점 높은 순이고, 만약 이때 평점 이 같아서 7개가 넘어갈 경우 평점 갯수가 많은 순으로 정렬합니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상위 평점 푸드트럭 조회 기능 추가: 평점 기준 상위 푸드트럭 목록(최대 7개)을 제공합니다.
  * 신규 API 엔드포인트 추가 (GET /top-rated): 인증된 사용자가 상위 푸드트럭을 조회할 수 있습니다.
* **문서**
  * OpenAPI/Swagger 응답 설명에 상위 평점 조회 항목 추가.
* **기타**
  * 상위 평점 응답용 간결한 반환 형식 추가로 결과가 요약되어 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->